### PR TITLE
Fjerning av oneOf og anyOf

### DIFF
--- a/kontrakter/da/felles/0.9/BasicTypes.schema.json
+++ b/kontrakter/da/felles/0.9/BasicTypes.schema.json
@@ -87,17 +87,12 @@
 					"description": "Kanskje fordi domstolene vil trenge å ta kontakt? Trenger vi både postadresse og besøksadresse?"
 				},				
 				"epost": {
-					"anyOf": [
-						{
-							"$ref": "#/definitions/EpostType"
-						},
-						{
-							"items": {
-								"$ref": "#/definitions/EpostType"
-							},
-							"type": "array"
-						}
-					]
+					"items": {
+						"$ref": "#/definitions/EpostType"
+					},
+					"minItems": 1,
+					"type": "array"
+				
 				},
 				"foedselsdato": {
 					"$ref": "#/definitions/xs:date",
@@ -112,17 +107,11 @@
 				},				
 				
 				"telefonnummer": {
-					"anyOf": [
-						{
-							"$ref": "#/definitions/TelefonnummerType"
-						},
-						{
-							"items": {
-								"$ref": "#/definitions/TelefonnummerType"
-							},
-							"type": "array"
-						}
-					]
+					"items": {
+						"$ref": "#/definitions/TelefonnummerType"
+					},
+					"minItems": 1,
+					"type": "array"
 				},
 				"tittel": {
 					"type": "string"
@@ -137,19 +126,12 @@
 					"type": "integer"
 				},
 				"verge": {
-					"anyOf": [
-						{
-							"$ref": "#/definitions/ProfesjonellPerson",
-							"description": "Referanse til person som er verge for denne personen. Vil peke på ProfesjonellPerson."
-						},
-						{
-							"items": {
-								"$ref": "#/definitions/ProfesjonellPerson",
-								"description": "Referanse til person som er verge for denne personen. Vil peke på ProfesjonellPerson."
-							},
-							"type": "array"
-						}
-					]
+					"items": {
+						"$ref": "#/definitions/ProfesjonellPerson",
+						"description": "Referanse til person som er verge for denne personen. Vil peke på ProfesjonellPerson."
+					},
+					"minItems": 1,
+					"type": "array"	
 				},
 				"forsvarer": {					
 					"$ref": "#/definitions/ProfesjonellPerson",
@@ -207,17 +189,10 @@
 					"$ref": "#/definitions/LandkodeType"
 				},
 				"adresselinje": {
-					"anyOf": [
-						{
-							"type": "string"
-						},
-						{
-							"items": {
-								"type": "string"
-							},
-							"type": "array"
-						}
-					]
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
 				},
 				"kommune": {
 					"type": "string"

--- a/kontrakter/da/varetekt/0.9/KjennelseVaretekt.combined.schema.json
+++ b/kontrakter/da/varetekt/0.9/KjennelseVaretekt.combined.schema.json
@@ -369,17 +369,11 @@
 					"description": "Kanskje fordi domstolene vil trenge å ta kontakt? Trenger vi både postadresse og besøksadresse?"
 				},				
 				"epost": {
-					"anyOf": [
-						{
-							"$ref": "#/definitions/EpostType"
-						},
-						{
-							"items": {
-								"$ref": "#/definitions/EpostType"
-							},
-							"type": "array"
-						}
-					]
+					"items": {
+						"$ref": "#/definitions/EpostType"
+					},
+					"minItems": 1,
+					"type": "array"	
 				},
 				"foedselsdato": {
 					"$ref": "#/definitions/Dato",
@@ -394,17 +388,11 @@
 				},				
 				
 				"telefonnummer": {
-					"anyOf": [
-						{
-							"$ref": "#/definitions/TelefonnummerType"
-						},
-						{
-							"items": {
-								"$ref": "#/definitions/TelefonnummerType"
-							},
-							"type": "array"
-						}
-					]
+					"items": {
+						"$ref": "#/definitions/TelefonnummerType"
+					},
+					"minItems": 1,
+					"type": "array"
 				},
 				"tittel": {
 					"type": "string"
@@ -419,19 +407,12 @@
 					"type": "integer"
 				},
 				"verge": {
-					"anyOf": [
-						{
-							"$ref": "#/definitions/ProfesjonellPerson",
-							"description": "Referanse til person som er verge for denne personen. Vil peke på ProfesjonellPerson."
-						},
-						{
-							"items": {
-								"$ref": "#/definitions/ProfesjonellPerson",
-								"description": "Referanse til person som er verge for denne personen. Vil peke på ProfesjonellPerson."
-							},
-							"type": "array"
-						}
-					]
+					"items": {
+						"$ref": "#/definitions/ProfesjonellPerson",
+						"description": "Referanse til person som er verge for denne personen. Vil peke på ProfesjonellPerson."
+					},
+					"minItems": 1,
+					"type": "array"
 				},
 				"forsvarer": {					
 					"$ref": "#/definitions/ProfesjonellPerson",
@@ -489,17 +470,11 @@
 					"$ref": "#/definitions/LandkodeType"
 				},
 				"adresselinje": {
-					"anyOf": [
-						{
-							"type": "string"
-						},
-						{
-							"items": {
-								"type": "string"
-							},
-							"type": "array"
-						}
-					]
+					"items": {
+						"type": "string"
+					},
+					"minItems": 1,
+					"type": "array"
 				},
 				"kommune": {
 					"type": "string"

--- a/kontrakter/politi/felles/1.0/person.schema.json
+++ b/kontrakter/politi/felles/1.0/person.schema.json
@@ -5,17 +5,7 @@
   "$defs" :{
     "adresseGradering" : {
       "description" : "Samme enum som folkeregisteret, ugradert hvis den ikke er gradert",
-      "type" : "string", "enum" : ["KLIENT_ADRESSE","FORTROLIG","STRENGT_FORTROLIG"]},
-
-    "personnavn": {
-      "type" : "object",
-      "properties": {
-        "fornavn" : {"type": "string"},
-        "mellomnavn" : {"type": "string"},
-        "etternavn" : {"type": "string"}
-        },
-      "required" : ["etternavn"],
-      "additionalProperties": false
+      "type" : "string", "enum" : ["KLIENT_ADRESSE","FORTROLIG","STRENGT_FORTROLIG"]
     },
 
     "foedselsnummer": {"type" : "string", "pattern": "[0-9]+", "minLength": 11, "maxLength": 11},
@@ -66,19 +56,38 @@
       "required" : ["etternavn"],
       "additionalProperties": false
     },
-
+    "personEllerForetak": {
+      "description": "Person eller foretak og straffesaksreferanse",
+      "type": "object",
+      "properties": {
+        "type": {"enum": ["person", "foretak"]},
+        "person": {"$ref": "#/$defs/personFullNivaa"},
+        "foretak": {"$ref": "#/$defs/foretakNivaa"}
+      },
+      "required": ["type"],
+      "oneOf": [
+        {
+          "properties":{
+            "type": {"const": "person" },
+            "foretak": {"type": "null"}
+          },
+          "required": ["person"]
+        },
+        {
+          "properties":{
+            "type": {"const": "foretak" },
+            "person": {"type": "null"}
+          },
+          "required": ["foretak"]
+        }
+      ]
+    },
+    
     "personForetakArray": {
       "type": "array",
       "title": "Array med person og/eller foretak",
       "items": {
-        "anyOf": [
-          {
-            "$ref": "#/$defs/personFullNivaa"
-          },
-          {
-            "$ref": "#/$defs/foretakNivaa"
-          }
-        ]
+        "$ref": "#/$defs/personEllerForetak"
       }
     },
     "personFullNivaa": {

--- a/kontrakter/politi/felles/1.0/person.schema.json
+++ b/kontrakter/politi/felles/1.0/person.schema.json
@@ -34,14 +34,6 @@
       "required": ["internId","navn"],
       "additionalProperties": false
     },
-    "foretakNivaa": {
-      "description": "Ekstra nivå for å få med foretak navn på item i miks liste",
-      "type": "object",
-      "required": ["foretak"],
-      "properties": {
-        "foretak" : {"$ref": "#/$defs/foretak"}
-      }
-    },
 
     "kjoenn" : {
       "description" : "Samme enum som folkeregisteret",
@@ -61,8 +53,8 @@
       "type": "object",
       "properties": {
         "type": {"enum": ["person", "foretak"]},
-        "person": {"$ref": "#/$defs/personFullNivaa"},
-        "foretak": {"$ref": "#/$defs/foretakNivaa"}
+        "person": {"$ref": "#/$defs/personFull"},
+        "foretak": {"$ref": "#/$defs/foretak"}
       },
       "required": ["type"],
       "oneOf": [
@@ -88,14 +80,6 @@
       "title": "Array med person og/eller foretak",
       "items": {
         "$ref": "#/$defs/personEllerForetak"
-      }
-    },
-    "personFullNivaa": {
-      "description": "Ekstra nivå for å få med person navn på item",
-      "type": "object",
-      "required": ["person"],
-      "properties": {
-        "person" : {"$ref": "#/$defs/personFull"}
       }
     },
 

--- a/kontrakter/politi/felles/1.0/siktelse.schema.json
+++ b/kontrakter/politi/felles/1.0/siktelse.schema.json
@@ -6,12 +6,34 @@
     "basissakerArray": {
       "type": "array",
       "description": "Liste over basissaker med referanse til person eller foretak",
-      "items" :{
-        "oneOf": [
-          {"$ref": "#/$defs/basissakPerson"},
-          {"$ref": "#/$defs/basissakForetak"}
-        ]
-      }
+      "items" : {"$ref": "#/$defs/basissakPersonEllerForetak"}
+    },
+    "basissakPersonEllerForetak": {
+      "description": "Person eller foretak og straffesaksreferanse",
+      "type": "object",
+      "properties": {
+        "straffesaksnummer": {"type": "string"},
+        "type": {"enum": ["person", "foretak"]},
+        "person": {"$ref": "#/references/personMini"},
+        "foretak": {"$ref": "#/references/foretakMini"}
+      },
+      "required": ["straffesaksnummer", "type"],
+      "oneOf": [
+        {
+          "properties":{
+            "type": {"const": "person" },
+            "foretak": {"type": "null"}
+          },
+          "required": ["person"]
+        },
+        {
+          "properties":{
+            "type": {"const": "foretak" },
+            "person": {"type": "null"}
+          },
+          "required": ["foretak"]
+        }
+      ]
     },
     "basissakPerson" : {
       "description": "Person og straffesaksreferanse",

--- a/kontrakter/politi/felles/1.0/varetekt.schema.json
+++ b/kontrakter/politi/felles/1.0/varetekt.schema.json
@@ -111,6 +111,32 @@
       ],
       "type": "string"
     },
+    "kjennelseEllerOrdreVaretekt": {
+      "description": "Kjennelse på varetektsfengsling fra domstolen eller påtale sin ordre/beslutning om fengsling i fengsel",
+      "type": "object",
+      "properties": {
+        "type": {"enum": ["kjennelse", "ordre"]},
+        "kjennelse": {"$ref": "#/definitions/kjennelseVaretekt"},
+        "foretak": {"$ref": "#/definitions/ordreVaretektPaatale"}
+      },
+      "required": ["type"],
+      "oneOf": [
+        {
+          "properties":{
+            "type": {"const": "kjennelse" },
+            "ordre": {"type": "null"}
+          },
+          "required": ["kjennelse"]
+        },
+        {
+          "properties":{
+            "type": {"const": "ordre" },
+            "kjennelse": {"type": "null"}
+          },
+          "required": ["ordre"]
+        }
+      ]
+    },
     "kjennelseVaretekt": {
       "description": "Kjennelse på varetektsfengsling fra domstolen som sendes til Kriminalomsorgen",
       "type": "object",
@@ -123,16 +149,6 @@
         "isolasjon": {"type" : "array", "items": {"$ref": "#/$defs/restriksjonKjennelse"}}
       }
     },
-    "kjennelseVaretektOneOf": {
-      "description": "Enkelt øvereste nivå på OneOf i hovedskjema",
-      "type": "object",
-      "required": ["kjennelse"],
-      "additionalProperties": true,
-      "properties": {
-        "merknad": {"type": "string"},
-        "kjennelse": {"$ref": "#/$defs/kjennelseVaretekt"}
-      }
-    }, 
     "ordreVaretektPaatale": {
       "description": "Påtale sin ordre/beslutning om fengsling i fengsel, før vi har en kjennelse fra retten og for å lette på restriksjoner, det er implisit at det er fengsling",
       "type": "object",
@@ -149,16 +165,6 @@
         "isolasjon": {"$ref": "#/$defs/isolasjonOrdre"}
       }
     },
-    "ordrePaataleOneOf": {
-      "description": "Enkelt øvereste nivå på OneOf i hovedskjema",
-      "type": "object",
-      "required": ["ordre"],
-      "additionalProperties": false,
-      "properties": {
-        "merknad": {"type": "string"},
-        "ordre": {"$ref": "#/$defs/ordreVaretektPaatale"}
-      }
-    },    
     "periodeStartAntall": {
       "description": "Periode for fensling eller restriksjon, bruker ikke å spesifisere startdato, derfor lengde og antall dager inn i fengslingen for restriksjoner",
       "type": "object",

--- a/kontrakter/politi/fengsling/1.0/gammel/innsettelsesordre.eksempel.schema.json
+++ b/kontrakter/politi/fengsling/1.0/gammel/innsettelsesordre.eksempel.schema.json
@@ -18,12 +18,7 @@
     "kontaktPersonKDI": { "$ref": "#/definitions/ansatt" },
     "varetektSyklusId": { "type": "string" },
     "ordreId": { "type": "string" },
-    "ordreKjennelse": {
-      "oneOf": [
-        { "$ref": "#/definitions/ordrePaataleOneOf" },
-        { "$ref": "#/definitions/kjennelseVaretektOneOf" }
-      ]
-    },
+    "ordreKjennelse": { "$ref": "#/definitions/kjennelseEllerOrdreVaretekt"},
     "paagrepetTidspunkt": {
       "type": "string",
       "format": "date-time"
@@ -393,6 +388,32 @@
       ],
       "type": "string"
     },
+    "kjennelseEllerOrdreVaretekt": {
+      "description": "Kjennelse på varetektsfengsling fra domstolen eller påtale sin ordre/beslutning om fengsling i fengsel",
+      "type": "object",
+      "properties": {
+        "type": {"enum": ["kjennelse", "ordre"]},
+        "kjennelse": {"$ref": "#/definitions/kjennelseVaretekt"},
+        "foretak": {"$ref": "#/definitions/ordreVaretektPaatale"}
+      },
+      "required": ["type"],
+      "oneOf": [
+        {
+          "properties":{
+            "type": {"const": "kjennelse" },
+            "ordre": {"type": "null"}
+          },
+          "required": ["kjennelse"]
+        },
+        {
+          "properties":{
+            "type": {"const": "ordre" },
+            "kjennelse": {"type": "null"}
+          },
+          "required": ["ordre"]
+        }
+      ]
+    },
     "kjennelseVaretekt": {
       "description": "Kjennelse på varetektsfengsling fra domstolen som sendes til Kriminalomsorgen",
       "type": "object",
@@ -409,16 +430,6 @@
           "type": "array",
           "items": { "$ref": "#/definitions/restriksjonKjennelse" }
         }
-      }
-    },
-    "kjennelseVaretektOneOf": {
-      "description": "Enkelt øvereste nivå på OneOf i hovedskjema",
-      "type": "object",
-      "required": [ "kjennelse" ],
-      "additionalProperties": true,
-      "properties": {
-        "merknad": { "type": "string" },
-        "kjennelse": { "$ref": "#/definitions/kjennelseVaretekt" }
       }
     },
     "ordreVaretektPaatale": {
@@ -438,16 +449,6 @@
         },
         "restriksjoner": { "$ref": "#/definitions/restriksjonerOrdre" },
         "isolasjon": { "$ref": "#/definitions/isolasjonOrdre" }
-      }
-    },
-    "ordrePaataleOneOf": {
-      "description": "Enkelt øvereste nivå på OneOf i hovedskjema",
-      "type": "object",
-      "required": [ "ordre" ],
-      "additionalProperties": false,
-      "properties": {
-        "merknad": { "type": "string" },
-        "ordre": { "$ref": "#/definitions/ordreVaretektPaatale" }
       }
     },
     "periodeStartAntall": {
@@ -597,18 +598,38 @@
       "required": [ "etternavn" ],
       "additionalProperties": false
     },
+    "personEllerForetak": {
+      "description": "Person eller foretak og straffesaksreferanse",
+      "type": "object",
+      "properties": {
+        "type": {"enum": ["person", "foretak"]},
+        "person": {"$ref": "#/definitions/personFullNivaa"},
+        "foretak": {"$ref": "#/definitions/foretakNivaa"}
+      },
+      "required": ["type"],
+      "oneOf": [
+        {
+          "properties":{
+            "type": {"const": "person" },
+            "foretak": {"type": "null"}
+          },
+          "required": ["person"]
+        },
+        {
+          "properties":{
+            "type": {"const": "foretak" },
+            "person": {"type": "null"}
+          },
+          "required": ["foretak"]
+        }
+      ]
+    },
+    
     "personForetakArray": {
       "type": "array",
       "title": "Array med person og/eller foretak",
       "items": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/personFullNivaa"
-          },
-          {
-            "$ref": "#/definitions/foretakNivaa"
-          }
-        ]
+        "$ref": "#/definitions/personEllerForetak"
       }
     },
     "personFullNivaa": {

--- a/kontrakter/politi/fengsling/1.0/gammel/innsettelsesordre.eksempel.schema.json
+++ b/kontrakter/politi/fengsling/1.0/gammel/innsettelsesordre.eksempel.schema.json
@@ -575,14 +575,6 @@
       "required": [ "internId", "navn" ],
       "additionalProperties": false
     },
-    "foretakNivaa": {
-      "description": "Ekstra nivå for å få med foretak navn på item i miks liste",
-      "type": "object",
-      "required": [ "foretak" ],
-      "properties": {
-        "foretak": { "$ref": "#/definitions/foretak" }
-      }
-    },
     "kjoenn": {
       "description": "Samme enum som folkeregisteret",
       "type": "string",
@@ -603,8 +595,8 @@
       "type": "object",
       "properties": {
         "type": {"enum": ["person", "foretak"]},
-        "person": {"$ref": "#/definitions/personFullNivaa"},
-        "foretak": {"$ref": "#/definitions/foretakNivaa"}
+        "person": {"$ref": "#/definitions/personFull"},
+        "foretak": {"$ref": "#/definitions/foretak"}
       },
       "required": ["type"],
       "oneOf": [
@@ -630,14 +622,6 @@
       "title": "Array med person og/eller foretak",
       "items": {
         "$ref": "#/definitions/personEllerForetak"
-      }
-    },
-    "personFullNivaa": {
-      "description": "Ekstra nivå for å få med person navn på item",
-      "type": "object",
-      "required": [ "person" ],
-      "properties": {
-        "person": { "$ref": "#/definitions/personFull" }
       }
     },
     "personFull": {

--- a/kontrakter/politi/fengsling/1.0/gammel/innsettelsesordre.schema.json
+++ b/kontrakter/politi/fengsling/1.0/gammel/innsettelsesordre.schema.json
@@ -27,7 +27,7 @@
         "kontaktPersonKDI": {"$ref": "#/references/ansatt"},
         "varetektSyklusId": {"type": "string"},
         "ordreId": {"type": "string"},
-        "ordreKjennelse": {"oneOf": [{"$ref": "#/references/ordrePaataleOneOf"},{"$ref": "#/references/kjennelseVaretektOneOf"}]},
+        "ordreKjennelse": {"$ref": "#/references/kjennelseEllerOrdreVaretekt"},
         "paagrepetTidspunkt": {"type": "string","format": "date-time"},
         "personVaretektInfo": {"$ref": "#/$defs/personVaretektInfo"},
         "paategningsdokumentRef": {"$ref": "#/references/dokumentRef"},
@@ -65,8 +65,7 @@
     "dokument": {"$ref": "../../felles/1.0/dokument.schema.json#/$defs/dokument"},
     "dokumentRef": {"$ref": "../../felles/1.0/dokument.schema.json#/$defs/dokumentRef"},
     "forsendelse": {"$ref": "../../felles/1.0/forsendelse.schema.json#/$defs/forsendelse"},
-    "kjennelseVaretektOneOf": {"$ref": "../../felles/1.0/varetekt.schema.json#/$defs/kjennelseVaretektOneOf"},
-    "ordrePaataleOneOf": {"$ref": "../../felles/1.0/varetekt.schema.json#/$defs/ordrePaataleOneOf"},
+    "kjennelseEllerOrdreVaretekt": {"$ref": "../../felles/1.0/varetekt.schema.json#/$defs/kjennelseEllerOrdreVaretekt"},
     "personFull": {"$ref": "../../felles/1.0/person.schema.json#/$defs/personFull"},
     "straffesakLovbudInvolverte": {"$ref": "../../felles/1.0/straffesak.schema.json#/$defs/straffesakLovbudInvolverte"}
   }

--- a/kontrakter/politi/fengsling/1.0/gammel/oppdaterVaretekt.schema.json
+++ b/kontrakter/politi/fengsling/1.0/gammel/oppdaterVaretekt.schema.json
@@ -25,7 +25,7 @@
         "varetektSyklusId": {"type": "string"},
         "personVaretekt": {"$ref": "#/references/personFull"},
         "ordreId": {"type": "string"},
-        "ordreKjennelse": {"oneOf": [{"$ref": "#/references/ordrePaataleOneOf"},{"$ref": "#/references/kjennelseVaretektOneOf"}]},
+        "ordreKjennelse": {"$ref": "#/references/kjennelseEllerOrdreVaretekt"},
         "paagrepetTidspunkt": {"type": "string","format": "date-time"},
         "dokumenter": {"type": "array", "items": {"$ref" : "#/references/dokument"}}
       }
@@ -35,8 +35,7 @@
     "ansatt" : {"$ref" : "../../felles/1.0/basistyper.schema.json#/$defs/ansatt"},
     "dokument": {"$ref": "../../felles/1.0/dokument.schema.json#/$defs/dokument"},
     "forsendelse": {"$ref": "../../felles/1.0/forsendelse.schema.json#/$defs/forsendelse"},
-    "kjennelseVaretektOneOf": {"$ref": "../../felles/1.0/varetekt.schema.json#/$defs/kjennelseVaretektOneOf"},
-    "ordrePaataleOneOf": {"$ref": "../../felles/1.0/varetekt.schema.json#/$defs/ordrePaataleOneOf"},
+    "kjennelseEllerOrdreVaretekt": {"$ref": "../../felles/1.0/varetekt.schema.json#/$defs/kjennelseEllerOrdreVaretekt"},
     "personFull": {"$ref": "../../felles/1.0/person.schema.json#/$defs/personFull"}
   }
 }

--- a/kontrakter/politi/fengsling/1.0/innsettelsesordre.schema.json
+++ b/kontrakter/politi/fengsling/1.0/innsettelsesordre.schema.json
@@ -10,7 +10,7 @@
     "kontaktPersonKDI": {"$ref": "#/definitions/ansatt"},
     "varetektSyklusId": {"type": "string"},
     "ordreId": {"type": "string"},
-    "ordreKjennelse": {"oneOf": [{"$ref": "#/definitions/ordrePaataleOneOf"},{"$ref": "#/definitions/kjennelseVaretektOneOf"}]},
+    "ordreKjennelse": {"$ref": "#/definitions/kjennelseEllerOrdreVaretekt"},
     "paagrepetTidspunkt": {"type": "string","format": "date-time"},
     "personVaretektInfo": {"$ref": "#/definitions/personVaretektInfo"},
     "paategningsdokumentRef": {"$ref": "#/definitions/dokumentRef"},
@@ -159,6 +159,32 @@
       ],
       "type": "string"
     },
+    "kjennelseEllerOrdreVaretekt": {
+      "description": "Kjennelse på varetektsfengsling fra domstolen eller påtale sin ordre/beslutning om fengsling i fengsel",
+      "type": "object",
+      "properties": {
+        "type": {"enum": ["kjennelse", "ordre"]},
+        "kjennelse": {"$ref": "#/definitions/kjennelseVaretekt"},
+        "foretak": {"$ref": "#/definitions/ordreVaretektPaatale"}
+      },
+      "required": ["type"],
+      "oneOf": [
+        {
+          "properties":{
+            "type": {"const": "kjennelse" },
+            "ordre": {"type": "null"}
+          },
+          "required": ["kjennelse"]
+        },
+        {
+          "properties":{
+            "type": {"const": "ordre" },
+            "kjennelse": {"type": "null"}
+          },
+          "required": ["ordre"]
+        }
+      ]
+    },
     "kjennelseVaretekt": {
       "description": "Kjennelse på varetektsfengsling fra domstolen som sendes til Kriminalomsorgen",
       "type": "object",
@@ -171,16 +197,6 @@
         "isolasjon": {"type" : "array", "items": {"$ref": "#/definitions/isolasjonKjennelse"}}
       }
     },
-    "kjennelseVaretektOneOf": {
-      "description": "Enkelt øvereste nivå på OneOf i hovedskjema",
-      "type": "object",
-      "required": ["kjennelse"],
-      "additionalProperties": true,
-      "properties": {
-        "merknad": {"type": "string"},
-        "kjennelse": {"$ref": "#/definitions/kjennelseVaretekt"}
-      }
-    }, 
     "ordreVaretektPaatale": {
       "description": "Påtale sin ordre/beslutning om fengsling i fengsel, før vi har en kjennelse fra retten og for å lette på restriksjoner, det er implisit at det er fengsling",
       "type": "object",
@@ -197,16 +213,6 @@
         "isolasjon": {"$ref": "#/definitions/isolasjonOrdre"}
       }
     },
-    "ordrePaataleOneOf": {
-      "description": "Enkelt øvereste nivå på OneOf i hovedskjema",
-      "type": "object",
-      "required": ["ordre"],
-      "additionalProperties": false,
-      "properties": {
-        "merknad": {"type": "string"},
-        "ordre": {"$ref": "#/definitions/ordreVaretektPaatale"}
-      }
-    },    
     "periodeStartAntall": {
       "description": "Periode for fensling eller restriksjon, bruker ikke å spesifisere startdato, derfor lengde og antall dager inn i fengslingen for restriksjoner",
       "type": "object",
@@ -494,16 +500,33 @@
     "personForetakArray": {
       "type": "array",
       "title": "Array med person og/eller foretak",
-      "items": {
-        "oneOf": [
-          {
-            "$ref": "#/definitions/personFullNivaa"
+      "items": {"$ref": "#/definitions/personEllerForetak"}
+    },
+    "personEllerForetak": {
+      "description": "Person eller foretak",
+      "type": "object",
+      "properties": {
+        "type": {"enum": ["person", "foretak"]},
+        "person": {"$ref": "#/definitions/personFullNivaa"},
+        "foretak": {"$ref": "#/definitions/foretakNivaa"}
+      },
+      "required": ["type"],
+      "oneOf": [
+        {
+          "properties":{
+            "type": {"const": "person" },
+            "foretak": {"type": "null"}
           },
-          {
-            "$ref": "#/definitions/foretakNivaa"
-          }
-        ]
-      }
+          "required": ["person"]
+        },
+        {
+          "properties":{
+            "type": {"const": "foretak" },
+            "person": {"type": "null"}
+          },
+          "required": ["foretak"]
+        }
+      ]
     },
     "personFullNivaa": {
       "description": "Ekstra nivå for å få med person navn på item",

--- a/kontrakter/politi/fengsling/1.0/innsettelsesordre.schema.json
+++ b/kontrakter/politi/fengsling/1.0/innsettelsesordre.schema.json
@@ -474,14 +474,6 @@
       "required": ["internId","navn"],
       "additionalProperties": false
     },
-    "foretakNivaa": {
-      "description": "Ekstra nivå for å få med foretak navn på item i miks liste",
-      "type": "object",
-      "required": ["foretak"],
-      "properties": {
-        "foretak" : {"$ref": "#/definitions/foretak"}
-      }
-    },
     "kjoenn" : {
       "description" : "Samme enum som folkeregisteret",
       "type" : "string", "enum" : ["KVINNE","MANN"]},
@@ -507,8 +499,8 @@
       "type": "object",
       "properties": {
         "type": {"enum": ["person", "foretak"]},
-        "person": {"$ref": "#/definitions/personFullNivaa"},
-        "foretak": {"$ref": "#/definitions/foretakNivaa"}
+        "person": {"$ref": "#/definitions/personFull"},
+        "foretak": {"$ref": "#/definitions/foretak"}
       },
       "required": ["type"],
       "oneOf": [
@@ -527,14 +519,6 @@
           "required": ["foretak"]
         }
       ]
-    },
-    "personFullNivaa": {
-      "description": "Ekstra nivå for å få med person navn på item",
-      "type": "object",
-      "required": ["person"],
-      "properties": {
-        "person" : {"$ref": "#/definitions/personFull"}
-      }
     },
 
     "personAdresse": {

--- a/kontrakter/politi/fengsling/1.0/oppdaterVaretekt.schema.json
+++ b/kontrakter/politi/fengsling/1.0/oppdaterVaretekt.schema.json
@@ -469,14 +469,6 @@
       "required": ["internId","navn"],
       "additionalProperties": false
     },
-    "foretakNivaa": {
-      "description": "Ekstra nivå for å få med foretak navn på item i miks liste",
-      "type": "object",
-      "required": ["foretak"],
-      "properties": {
-        "foretak" : {"$ref": "#/definitions/foretak"}
-      }
-    },
 
     "kjoenn" : {
       "description" : "Samme enum som folkeregisteret",
@@ -496,8 +488,8 @@
       "type": "object",
       "properties": {
         "type": {"enum": ["person", "foretak"]},
-        "person": {"$ref": "#/definitions/personFullNivaa"},
-        "foretak": {"$ref": "#/definitions/foretakNivaa"}
+        "person": {"$ref": "#/definitions/personFull"},
+        "foretak": {"$ref": "#/definitions/foretak"}
       },
       "required": ["type"],
       "oneOf": [
@@ -523,14 +515,6 @@
       "title": "Array med person og/eller foretak",
       "items": {
         "$ref": "#/definitions/personEllerForetak"
-      }
-    },
-    "personFullNivaa": {
-      "description": "Ekstra nivå for å få med person navn på item",
-      "type": "object",
-      "required": ["person"],
-      "properties": {
-        "person" : {"$ref": "#/definitions/personFull"}
       }
     },
    

--- a/kontrakter/politi/fengsling/1.0/oppdaterVaretekt.schema.json
+++ b/kontrakter/politi/fengsling/1.0/oppdaterVaretekt.schema.json
@@ -9,7 +9,7 @@
     "varetektSyklusId": {"type": "string"},
     "personVaretekt": {"$ref": "#/definitions/personFull"},
     "ordreId": {"type": "string"},
-    "ordreKjennelse": {"oneOf": [{"$ref": "#/definitions/ordrePaataleOneOf"},{"$ref": "#/definitions/kjennelseVaretektOneOf"}]},
+    "ordreKjennelse": {"$ref": "#/definitions/kjennelseEllerOrdreVaretekt"},
     "paagrepetTidspunkt": {"type": "string","format": "date-time"},
     "dokumenter": {"type": "array", "items": {"$ref" : "#/definitions/dokument"}}
   },
@@ -319,7 +319,32 @@
       ],
       "type": "string"
     },
-
+    "kjennelseEllerOrdreVaretekt": {
+      "description": "Kjennelse på varetektsfengsling fra domstolen eller påtale sin ordre/beslutning om fengsling i fengsel",
+      "type": "object",
+      "properties": {
+        "type": {"enum": ["kjennelse", "ordre"]},
+        "kjennelse": {"$ref": "#/definitions/kjennelseVaretekt"},
+        "foretak": {"$ref": "#/definitions/ordreVaretektPaatale"}
+      },
+      "required": ["type"],
+      "oneOf": [
+        {
+          "properties":{
+            "type": {"const": "kjennelse" },
+            "ordre": {"type": "null"}
+          },
+          "required": ["kjennelse"]
+        },
+        {
+          "properties":{
+            "type": {"const": "ordre" },
+            "kjennelse": {"type": "null"}
+          },
+          "required": ["ordre"]
+        }
+      ]
+    },
     "kjennelseVaretekt": {
       "description": "Kjennelse på varetektsfengsling fra domstolen som sendes til Kriminalomsorgen",
       "type": "object",
@@ -332,15 +357,6 @@
         "isolasjon": {"type" : "array", "items": {"$ref": "#/definitions/isolasjonKjennelse"}}
       }
     },
-    "kjennelseVaretektOneOf": {
-      "description": "Enkelt øvereste nivå på OneOf i hovedskjema",
-      "type": "object",
-      "required": ["kjennelse"],
-      "additionalProperties": true,
-      "properties": {
-        "kjennelse": {"$ref": "#/definitions/kjennelseVaretekt"}
-      }
-    }, 
     "ordreVaretektPaatale": {
       "description": "Påtale sin ordre/beslutning om fengsling i fengsel, før vi har en kjennelse fra retten og for å lette på restriksjoner, det er implisit at det er fengsling",
       "type": "object",
@@ -357,15 +373,6 @@
         "isolasjon": {"$ref": "#/definitions/isolasjonOrdre"}
       }
     },
-    "ordrePaataleOneOf": {
-      "description": "Enkelt øvereste nivå på OneOf i hovedskjema",
-      "type": "object",
-      "required": ["ordre"],
-      "additionalProperties": false,
-      "properties": {
-        "ordre": {"$ref": "#/definitions/ordreVaretektPaatale"}
-      }
-    },    
     "periodeStartAntall": {
       "description": "Periode for fensling eller restriksjon, bruker ikke å spesifisere startdato, derfor lengde og antall dager inn i fengslingen for restriksjoner",
       "type": "object",
@@ -484,19 +491,38 @@
       "required" : ["etternavn"],
       "additionalProperties": false
     },
+    "personEllerForetak": {
+      "description": "Person eller foretak og straffesaksreferanse",
+      "type": "object",
+      "properties": {
+        "type": {"enum": ["person", "foretak"]},
+        "person": {"$ref": "#/definitions/personFullNivaa"},
+        "foretak": {"$ref": "#/definitions/foretakNivaa"}
+      },
+      "required": ["type"],
+      "oneOf": [
+        {
+          "properties":{
+            "type": {"const": "person" },
+            "foretak": {"type": "null"}
+          },
+          "required": ["person"]
+        },
+        {
+          "properties":{
+            "type": {"const": "foretak" },
+            "person": {"type": "null"}
+          },
+          "required": ["foretak"]
+        }
+      ]
+    },
 
     "personForetakArray": {
       "type": "array",
       "title": "Array med person og/eller foretak",
       "items": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/personFullNivaa"
-          },
-          {
-            "$ref": "#/definitions/foretakNivaa"
-          }
-        ]
+        "$ref": "#/definitions/personEllerForetak"
       }
     },
     "personFullNivaa": {

--- a/kontrakter/politi/varetekt/1.0/begjaeringVaretekt.json
+++ b/kontrakter/politi/varetekt/1.0/begjaeringVaretekt.json
@@ -341,26 +341,24 @@
             {
               "type": "person",
               "person": {
-                "person": {
-                  "internId": "700892415",
-                  "navn": {
-                    "fornavn": "Masse",
-                    "etternavn": "KIWI"
-                  },
-                  "foedselsnummer": ["19877099302"],
-                  "kjoenn": "MANN",
-                  "foedselsdato": "1970-07-19",
-                  "statsborgerskap": [
-                    {
-                      "kode": "NOR",
-                      "navn": "Norge"
-                    }],
+                "internId": "700892415",
+                "navn": {
+                  "fornavn": "Masse",
+                  "etternavn": "KIWI"
+                },
+                "foedselsnummer": ["19877099302"],
+                "kjoenn": "MANN",
+                "foedselsdato": "1970-07-19",
+                "statsborgerskap": [
+                  {
+                    "kode": "NOR",
+                    "navn": "Norge"
+                  }],
+                "adresse": {
                   "adresse": {
-                    "adresse": {
-                      "adresselinjer": ["Rugdeberget 2"],
-                      "postnummer": "1266",
-                      "poststed": "OSLO"
-                    }
+                    "adresselinjer": ["Rugdeberget 2"],
+                    "postnummer": "1266",
+                    "poststed": "OSLO"
                   }
                 }
               }
@@ -368,37 +366,33 @@
             {
               "type": "foretak",
               "foretak": {
-                "foretak": {
-                  "internId": "340078107",
-                  "organisasjonsnummer": "984954808",
-                  "navn": "Obs"
-                }
+                "internId": "340078107",
+                "organisasjonsnummer": "984954808",
+                "navn": "Obs"
               }
             }],
           "fornaermede": [
             {
               "type": "person",
               "person": {
-                "person": {
-                  "internId": "700892735",
-                  "navn": {
-                    "fornavn": "Sannferdig",
-                    "etternavn": "KOS"
-                  },
-                  "foedselsnummer": ["31907499858"],
-                  "kjoenn": "KVINNE",
-                  "foedselsdato": "1974-10-31",
-                  "statsborgerskap": [
-                    {
-                      "kode": "NOR",
-                      "navn": "Norge"
-                    }],
+                "internId": "700892735",
+                "navn": {
+                  "fornavn": "Sannferdig",
+                  "etternavn": "KOS"
+                },
+                "foedselsnummer": ["31907499858"],
+                "kjoenn": "KVINNE",
+                "foedselsdato": "1974-10-31",
+                "statsborgerskap": [
+                  {
+                    "kode": "NOR",
+                    "navn": "Norge"
+                  }],
+                "adresse": {
                   "adresse": {
-                    "adresse": {
-                      "adresselinjer": ["Bratsberggata 29"],
-                      "postnummer": "3714",
-                      "poststed": "SKIEN"
-                    }
+                    "adresselinjer": ["Bratsberggata 29"],
+                    "postnummer": "3714",
+                    "poststed": "SKIEN"
                   }
                 }
               }
@@ -462,26 +456,24 @@
             {
               "type": "person",
               "person": {
-                "person": {
-                  "internId": "700892415",
-                  "navn": {
-                    "fornavn": "Masse",
-                    "etternavn": "KIWI"
-                  },
-                  "foedselsnummer": ["19877099302"],
-                  "kjoenn": "MANN",
-                  "foedselsdato": "1970-07-19",
-                  "statsborgerskap": [
-                    {
-                      "kode": "NOR",
-                      "navn": "Norge"
-                    }],
+                "internId": "700892415",
+                "navn": {
+                  "fornavn": "Masse",
+                  "etternavn": "KIWI"
+                },
+                "foedselsnummer": ["19877099302"],
+                "kjoenn": "MANN",
+                "foedselsdato": "1970-07-19",
+                "statsborgerskap": [
+                  {
+                    "kode": "NOR",
+                    "navn": "Norge"
+                  }],
+                "adresse": {
                   "adresse": {
-                    "adresse": {
-                      "adresselinjer": ["Rugdeberget 2"],
-                      "postnummer": "1266",
-                      "poststed": "OSLO"
-                    }
+                    "adresselinjer": ["Rugdeberget 2"],
+                    "postnummer": "1266",
+                    "poststed": "OSLO"
                   }
                 }
               }
@@ -490,11 +482,9 @@
             {
               "type": "foretak",
               "foretak": {
-                "foretak": {
-                  "internId": "60044820",
-                  "organisasjonsnummer": "976878442",
-                  "navn": "Rema 100"
-                }
+                "internId": "60044820",
+                "organisasjonsnummer": "976878442",
+                "navn": "Rema 100"
               }
             }],
           "vitne": [
@@ -548,20 +538,18 @@
             {
               "type": "person",
               "person": {
-                "person": {
-                  "internId": "700892547",
-                  "navn": {
-                    "fornavn": "Lormen",
-                    "etternavn": "QUATRO"
-                  },
-                  "kjoenn": "MANN",
-                  "foedselsdato": "1978-01-12",
-                  "statsborgerskap": [
-                    {
-                      "kode": "ITA",
-                      "navn": "Italia"
-                    }]
-                }
+                "internId": "700892547",
+                "navn": {
+                  "fornavn": "Lormen",
+                  "etternavn": "QUATRO"
+                },
+                "kjoenn": "MANN",
+                "foedselsdato": "1978-01-12",
+                "statsborgerskap": [
+                  {
+                    "kode": "ITA",
+                    "navn": "Italia"
+                  }]
               }
             }]
         }
@@ -600,26 +588,24 @@
             {
               "type": "person",
               "person": {
-                "person": {
-                  "internId": "700892735",
-                  "navn": {
-                    "fornavn": "Sannferdig",
-                    "etternavn": "KOS"
-                  },
-                  "foedselsnummer": ["31907499858"],
-                  "kjoenn": "KVINNE",
-                  "foedselsdato": "1974-10-31",
-                  "statsborgerskap": [
-                    {
-                      "kode": "NOR",
-                      "navn": "Norge"
-                    }],
+                "internId": "700892735",
+                "navn": {
+                  "fornavn": "Sannferdig",
+                  "etternavn": "KOS"
+                },
+                "foedselsnummer": ["31907499858"],
+                "kjoenn": "KVINNE",
+                "foedselsdato": "1974-10-31",
+                "statsborgerskap": [
+                  {
+                    "kode": "NOR",
+                    "navn": "Norge"
+                  }],
+                "adresse": {
                   "adresse": {
-                    "adresse": {
-                      "adresselinjer": ["Bratsberggata 29"],
-                      "postnummer": "3714",
-                      "poststed": "SKIEN"
-                    }
+                    "adresselinjer": ["Bratsberggata 29"],
+                    "postnummer": "3714",
+                    "poststed": "SKIEN"
                   }
                 }
               }

--- a/kontrakter/politi/varetekt/1.0/begjaeringVaretekt.json
+++ b/kontrakter/politi/varetekt/1.0/begjaeringVaretekt.json
@@ -40,9 +40,11 @@
             "navn": "Norge"
           }],
         "adresse": {
-          "adresselinjer": ["Bjørklund 21"],
-          "postnummer": "4137",
-          "poststed": "ÅRDAL I RYFYLKE"
+          "adresse":{
+            "adresselinjer": ["Bjørklund 21"],
+            "postnummer": "4137",
+            "poststed": "ÅRDAL I RYFYLKE"
+          }
         }
       },
       "forsvarer": {
@@ -172,6 +174,7 @@
                 "grunnlagstekst": "Campingbil med kokeutstyr og Breaking Bad DVD'er",
                 "basissaker": [
                   {
+                    "type": "person",
                     "straffesaksnummer": "15434820",
                     "person": {
                       "internId": "700892415",
@@ -183,6 +186,7 @@
                     }
                   },
                   {
+                    "type": "person",
                     "straffesaksnummer": "15434820",
                     "person": {
                       "internId": "700892414",
@@ -210,6 +214,7 @@
                 "grunnlagstekst": "Lormen Quatro ble lappet til av Morsom Kiwi så han blødde neseblod.",
                 "basissaker": [
                   {
+                    "type": "person",
                     "straffesaksnummer": "15434821",
                     "person": {
                       "internId": "700892414",
@@ -237,6 +242,7 @@
                 "grunnlagstekst": "Torsdag 1. januar 2015 kl. 00.00 i Walmannsvegen 81 i Eidskog truet Morsom Kiwi fornærmede med en avsaget hagle.",
                 "basissaker": [
                   {
+                    "type": "person",
                     "straffesaksnummer": "15434850",
                     "person": {
                       "internId": "700892414",
@@ -264,6 +270,7 @@
                 "grunnlagstekst": "Lørdag 1. januar 2022 kl. 00.00 i Waldemar Carlsens veg 4 i Kongsvinger tok Morsom Kiwi og Masse Kiwi og grisebanket dama til Morsom Kiwi Sannferdig Kos. Sannferdig Kos fikk fire knekte ribbeing, knust nese og knekt fot.",
                 "basissaker": [
                   {
+                    "type": "person",
                     "straffesaksnummer": "15434819",
                     "person": {
                       "internId": "700892414",
@@ -275,6 +282,7 @@
                     }
                   },
                   {
+                    "type": "person",
                     "straffesaksnummer": "15434819",
                     "person": {
                       "internId": "700892415",
@@ -286,6 +294,7 @@
                     }
                   },
                   {
+                    "type": "foretak",
                     "straffesaksnummer": "15434819",
                     "foretak": {
                       "internId": "340078107",
@@ -330,54 +339,67 @@
           },
           "medsiktede": [
             {
+              "type": "person",
               "person": {
-                "internId": "700892415",
-                "navn": {
-                  "fornavn": "Masse",
-                  "etternavn": "KIWI"
-                },
-                "foedselsnummer": ["19877099302"],
-                "kjoenn": "MANN",
-                "foedselsdato": "1970-07-19",
-                "statsborgerskap": [
-                  {
-                    "kode": "NOR",
-                    "navn": "Norge"
-                  }],
-                "adresse": {
-                  "adresselinjer": ["Rugdeberget 2"],
-                  "postnummer": "1266",
-                  "poststed": "OSLO"
+                "person": {
+                  "internId": "700892415",
+                  "navn": {
+                    "fornavn": "Masse",
+                    "etternavn": "KIWI"
+                  },
+                  "foedselsnummer": ["19877099302"],
+                  "kjoenn": "MANN",
+                  "foedselsdato": "1970-07-19",
+                  "statsborgerskap": [
+                    {
+                      "kode": "NOR",
+                      "navn": "Norge"
+                    }],
+                  "adresse": {
+                    "adresse": {
+                      "adresselinjer": ["Rugdeberget 2"],
+                      "postnummer": "1266",
+                      "poststed": "OSLO"
+                    }
+                  }
                 }
               }
             },
             {
+              "type": "foretak",
               "foretak": {
-                "internId": "340078107",
-                "organisasjonsnummer": "984954808",
-                "navn": "Obs"
+                "foretak": {
+                  "internId": "340078107",
+                  "organisasjonsnummer": "984954808",
+                  "navn": "Obs"
+                }
               }
             }],
           "fornaermede": [
             {
+              "type": "person",
               "person": {
-                "internId": "700892735",
-                "navn": {
-                  "fornavn": "Sannferdig",
-                  "etternavn": "KOS"
-                },
-                "foedselsnummer": ["31907499858"],
-                "kjoenn": "KVINNE",
-                "foedselsdato": "1974-10-31",
-                "statsborgerskap": [
-                  {
-                    "kode": "NOR",
-                    "navn": "Norge"
-                  }],
-                "adresse": {
-                  "adresselinjer": ["Bratsberggata 29"],
-                  "postnummer": "3714",
-                  "poststed": "SKIEN"
+                "person": {
+                  "internId": "700892735",
+                  "navn": {
+                    "fornavn": "Sannferdig",
+                    "etternavn": "KOS"
+                  },
+                  "foedselsnummer": ["31907499858"],
+                  "kjoenn": "KVINNE",
+                  "foedselsdato": "1974-10-31",
+                  "statsborgerskap": [
+                    {
+                      "kode": "NOR",
+                      "navn": "Norge"
+                    }],
+                  "adresse": {
+                    "adresse": {
+                      "adresselinjer": ["Bratsberggata 29"],
+                      "postnummer": "3714",
+                      "poststed": "SKIEN"
+                    }
+                  }
                 }
               }
             }],
@@ -397,9 +419,11 @@
                   "navn": "Norge"
                 }],
               "adresse": {
-                "adresselinjer": ["Øvstedalsvegen 87"],
-                "postnummer": "6391",
-                "poststed": "TRESFJORD"
+                "adresse": {
+                  "adresselinjer": ["Øvstedalsvegen 87"],
+                  "postnummer": "6391",
+                  "poststed": "TRESFJORD"
+                }
               }
             }]
         }
@@ -436,33 +460,41 @@
           },
           "medsiktede": [
             {
+              "type": "person",
               "person": {
-                "internId": "700892415",
-                "navn": {
-                  "fornavn": "Masse",
-                  "etternavn": "KIWI"
-                },
-                "foedselsnummer": ["19877099302"],
-                "kjoenn": "MANN",
-                "foedselsdato": "1970-07-19",
-                "statsborgerskap": [
-                  {
-                    "kode": "NOR",
-                    "navn": "Norge"
-                  }],
-                "adresse": {
-                  "adresselinjer": ["Rugdeberget 2"],
-                  "postnummer": "1266",
-                  "poststed": "OSLO"
+                "person": {
+                  "internId": "700892415",
+                  "navn": {
+                    "fornavn": "Masse",
+                    "etternavn": "KIWI"
+                  },
+                  "foedselsnummer": ["19877099302"],
+                  "kjoenn": "MANN",
+                  "foedselsdato": "1970-07-19",
+                  "statsborgerskap": [
+                    {
+                      "kode": "NOR",
+                      "navn": "Norge"
+                    }],
+                  "adresse": {
+                    "adresse": {
+                      "adresselinjer": ["Rugdeberget 2"],
+                      "postnummer": "1266",
+                      "poststed": "OSLO"
+                    }
+                  }
                 }
               }
             }],
           "fornaermede": [
             {
+              "type": "foretak",
               "foretak": {
-                "internId": "60044820",
-                "organisasjonsnummer": "976878442",
-                "navn": "Rema 100"
+                "foretak": {
+                  "internId": "60044820",
+                  "organisasjonsnummer": "976878442",
+                  "navn": "Rema 100"
+                }
               }
             }],
           "vitne": [
@@ -514,19 +546,22 @@
           },
           "fornaermede": [
             {
+              "type": "person",
               "person": {
-                "internId": "700892547",
-                "navn": {
-                  "fornavn": "Lormen",
-                  "etternavn": "QUATRO"
-                },
-                "kjoenn": "MANN",
-                "foedselsdato": "1978-01-12",
-                "statsborgerskap": [
-                  {
-                    "kode": "ITA",
-                    "navn": "Italia"
-                  }]
+                "person": {
+                  "internId": "700892547",
+                  "navn": {
+                    "fornavn": "Lormen",
+                    "etternavn": "QUATRO"
+                  },
+                  "kjoenn": "MANN",
+                  "foedselsdato": "1978-01-12",
+                  "statsborgerskap": [
+                    {
+                      "kode": "ITA",
+                      "navn": "Italia"
+                    }]
+                }
               }
             }]
         }
@@ -563,24 +598,29 @@
           },
           "fornaermede": [
             {
+              "type": "person",
               "person": {
-                "internId": "700892735",
-                "navn": {
-                  "fornavn": "Sannferdig",
-                  "etternavn": "KOS"
-                },
-                "foedselsnummer": ["31907499858"],
-                "kjoenn": "KVINNE",
-                "foedselsdato": "1974-10-31",
-                "statsborgerskap": [
-                  {
-                    "kode": "NOR",
-                    "navn": "Norge"
-                  }],
-                "adresse": {
-                  "adresselinjer": ["Bratsberggata 29"],
-                  "postnummer": "3714",
-                  "poststed": "SKIEN"
+                "person": {
+                  "internId": "700892735",
+                  "navn": {
+                    "fornavn": "Sannferdig",
+                    "etternavn": "KOS"
+                  },
+                  "foedselsnummer": ["31907499858"],
+                  "kjoenn": "KVINNE",
+                  "foedselsdato": "1974-10-31",
+                  "statsborgerskap": [
+                    {
+                      "kode": "NOR",
+                      "navn": "Norge"
+                    }],
+                  "adresse": {
+                    "adresse": {
+                      "adresselinjer": ["Bratsberggata 29"],
+                      "postnummer": "3714",
+                      "poststed": "SKIEN"
+                    }
+                  }
                 }
               }
             }]


### PR DESCRIPTION
Her er ett forslag til hvordan vi kan slutte å bruker oneOf og anyOf for å definere objekt typene våre.

Problem:
Kotlin kodegeneratoren vi bruker forstår ikke `oneOf` og `anyOf`, så ett object som er definert med det som type, blir til typen `Any`.

Løsning:
Istedet for å si at en property følger enten schema `A` eller schema `B`, kan vi dele propertyen i to, og legge til en enum som sier hvilket schema propertyen følger.

Det er en struktur som kodegeneratoren forstår.

Validering:
Jeg merket at selv om kodegeneratoren støtter den nye strukturen, så støtter den ikke valideringen av den.
Det kan vi løse med eksplisitt validering.



Det er litt forskjellige måter å løse dette på, greit oppsummert her:
https://stackoverflow.com/questions/38717933/jsonschema-attribute-conditionally-required
og her:
https://json-schema.org/understanding-json-schema/reference/conditionals.html

Jeg har testet `enum` måten, og `if-then-else` metoden, og `enum` metoden fungerer med de to kotlin-json-schema verktøyene vi bruker, mens `if-then-else` ville ikke la seg validere, selv om kodegenereringa gikk ok.
Jeg syns også `enum` er mest lesbar, og kan lett utvides med fler enn to typer.

Merk:
Kun `begjaeringVaretekt.json` eksempelet er oppdatert.
Vi vil ikke nødvendigvis merge denne PR, men det er ett forslag til hvordan dette kan løses.


kotlin-kodegeneratoren:
https://github.com/pwall567/json-kotlin-gradle
kotlin-json-schema-validator:
https://github.com/pwall567/json-kotlin-schema