### PR TITLE
Deploy av maven artefakt

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,3 +1,5 @@
+on: workflow_dispatch
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-on: workflow_dispatch
+on: push
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,37 @@
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Build with Maven
+        run: mvn -B package -Drevision=$GITHUB_SHA
+
+      - name: Publish to GitHub Packages Apache Maven
+        run: mvn deploy
+        env:
+          GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
+
+#      - name: Set up Apache Maven Central
+#        uses: actions/setup-java@v3
+#        with: # running setup-java again overwrites the settings.xml
+#          distribution: 'temurin'
+#          java-version: '11'
+#          server-id: maven # Value of the distributionManagement/repository/id field of the pom.xml
+#          server-username: MAVEN_USERNAME # env variable for username in deploy
+#          server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
+#          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+#          gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+#
+#      - name: Publish to Apache Maven Central
+#        run: mvn deploy
+#        env:
+#          MAVEN_USERNAME: maven_username123
+#          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+#          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,20 +20,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
 
-#      - name: Set up Apache Maven Central
-#        uses: actions/setup-java@v3
-#        with: # running setup-java again overwrites the settings.xml
-#          distribution: 'temurin'
-#          java-version: '11'
-#          server-id: maven # Value of the distributionManagement/repository/id field of the pom.xml
-#          server-username: MAVEN_USERNAME # env variable for username in deploy
-#          server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
-#          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
-#          gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
-#
-#      - name: Publish to Apache Maven Central
-#        run: mvn deploy
-#        env:
-#          MAVEN_USERNAME: maven_username123
-#          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
-#          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+      - name: Set up Apache Maven Central
+        uses: actions/setup-java@v3
+        with: # running setup-java again overwrites the settings.xml
+          distribution: 'temurin'
+          java-version: '11'
+          server-id: maven # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: MAVEN_USERNAME # env variable for username in deploy
+          server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+
+      - name: Publish to Apache Maven Central
+        run: mvn deploy -Drevision=$GITHUB_SHA
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
         run: mvn -B package -Drevision=$GITHUB_SHA
 
       - name: Publish to GitHub Packages Apache Maven
-        run: mvn deploy
+        run: mvn deploy -Drevision=$GITHUB_SHA
         env:
           GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,12 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
 
       - name: Publish to Apache Maven Central
-        run: mvn deploy -Drevision=$GITHUB_SHA
+        run: |
+          DATE_FORMATTED=`date +%d%m%Y`
+          GIT_SHA_SHORT=`echo $GITHUB_SHA | cut -c1-7`
+          NEW_VERSION=${DATE_FORMATTED}.${GIT_SHA_SHORT}
+          mvn versions:set -DnewVersion=${NEW_VERSION} -DgenerateBackupPoms=false
+          mvn deploy -P=ossrh
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,26 +6,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-
-      - name: Build with Maven
-        run: mvn -B package -Drevision=$GITHUB_SHA
-
-      - name: Publish to GitHub Packages Apache Maven
-        run: mvn deploy -Drevision=$GITHUB_SHA
-        env:
-          GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
-
       - name: Set up Apache Maven Central
         uses: actions/setup-java@v3
         with: # running setup-java again overwrites the settings.xml
           distribution: 'temurin'
           java-version: '11'
-          server-id: maven # Value of the distributionManagement/repository/id field of the pom.xml
+          server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username in deploy
           server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+    branches:
+      - 'main'
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+target

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 target
+.iml

--- a/kontrakter/politi/varetekt/pom.xml
+++ b/kontrakter/politi/varetekt/pom.xml
@@ -3,12 +3,12 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>begjaering-varetekt</artifactId>
     <packaging>jar</packaging>
-    <name>${artifactId}</name>
+    <name>Begjæring om varetekt</name>
     <description>JSON-schema for begjæring om varetekt</description>
 
     <parent>
-        <groupId>io.github.domstolene</groupId>
-        <artifactId>esas-kontrakter</artifactId>
+        <groupId>io.github.domstolene.esas</groupId>
+        <artifactId>kontrakter</artifactId>
         <version>tmp</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
@@ -16,10 +16,10 @@
     <build>
         <resources>
             <resource>
-                <targetPath>esas/varetekt</targetPath>
+                <targetPath>schema</targetPath>
                 <directory>./</directory>
                 <includes>
-                    <include>**/*.schema.json</include>
+                    <include>**/*.json</include>
                 </includes>
             </resource>
         </resources>

--- a/kontrakter/politi/varetekt/pom.xml
+++ b/kontrakter/politi/varetekt/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>begjaering-varetekt</artifactId>
+    <packaging>jar</packaging>
+    <name>${artifactId}</name>
+    <description>JSON-schema for begjæring om varetekt</description>
+
+    <parent>
+        <groupId>io.github.domstolene</groupId>
+        <artifactId>esas-kontrakter</artifactId>
+        <version>tmp</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <build>
+        <resources>
+            <resource>
+                <targetPath>esas/varetekt</targetPath>
+                <directory>./</directory>
+                <includes>
+                    <include>**/*.schema.json</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,23 +44,31 @@
                 </includes>
             </resource>
         </resources>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+
     </build>
+    <profiles>
+        <profile>
+            <id>ossrh</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.github.domstolene</groupId>
-    <artifactId>esas-kontrakter</artifactId>
+    <groupId>io.github.domstolene.esas</groupId>
+    <artifactId>kontrakter</artifactId>
     <version>tmp</version>
     <packaging>pom</packaging>
     <url>https://github.com/domstolene/ESAS</url>
-    <name>${artifactId}</name>
+    <name>ESAS-kontrakter</name>
     <description>Parent for kontrakter definert i ESAS-prosjektet</description>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,9 @@
     <artifactId>esas-kontrakter</artifactId>
     <version>tmp</version>
     <packaging>pom</packaging>
-    <description>Json-schemaer definert i ESAS-prosjektet</description>
     <url>https://github.com/domstolene/ESAS</url>
+    <name>${artifactId}</name>
+    <description>Parent for kontrakter definert i ESAS-prosjektet</description>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,33 @@
     <groupId>no.esas</groupId>
     <artifactId>kontrakter</artifactId>
     <version>${revision}</version>
+    <packaging>jar</packaging>
+    <description>Json-schemaer definert i ESAS-prosjektet</description>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <organization>Politiet</organization>
+            <organizationUrl>https://www.politiet.no</organizationUrl>
+        </developer>
+        <developer>
+            <organization>Norges domstoler</organization>
+            <organizationUrl>https://www.domstol.no</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <developerConnection>scm:git:git@github.com:domstolene/ESAS.git</developerConnection>
+        <connection>scm:git:git@github.com:domstolene/ESAS.git</connection>
+        <url>https://github.com/domstolene/ESAS</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <build>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <packaging>jar</packaging>
     <description>Json-schemaer definert i ESAS-prosjektet</description>
     <url>https://github.com/domstolene/ESAS</url>
+    <name>ESAS-kontrakter</name>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
                 <targetPath>esas/varetekt</targetPath>
                 <directory>kontrakter/politi/varetekt</directory>
                 <includes>
-                    <include>**/*.json</include>
+                    <include>**/*.schema.json</include>
                 </includes>
             </resource>
         </resources>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.esas</groupId>
     <artifactId>kontrakter</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <build>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <version>${revision}</version>
     <packaging>jar</packaging>
     <description>Json-schemaer definert i ESAS-prosjektet</description>
+    <url>https://github.com/domstolene/ESAS</url>
 
     <licenses>
         <license>
@@ -42,6 +43,22 @@
                 </includes>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -16,4 +16,11 @@
             </resource>
         </resources>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/domstolene/esas</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,9 @@
 
     <distributionManagement>
         <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/domstolene/esas</url>
+            <id>ossrh</id>
+            <name>Central Repository OSSRH</name>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,10 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.domstolene</groupId>
     <artifactId>esas-kontrakter</artifactId>
-    <version>${revision}</version>
-    <packaging>jar</packaging>
+    <version>tmp</version>
+    <packaging>pom</packaging>
     <description>Json-schemaer definert i ESAS-prosjektet</description>
     <url>https://github.com/domstolene/ESAS</url>
-    <name>ESAS-kontrakter</name>
 
     <licenses>
         <license>
@@ -34,18 +33,10 @@
         <tag>HEAD</tag>
     </scm>
 
-    <build>
-        <resources>
-            <resource>
-                <targetPath>esas/varetekt</targetPath>
-                <directory>kontrakter/politi/varetekt</directory>
-                <includes>
-                    <include>**/*.schema.json</include>
-                </includes>
-            </resource>
-        </resources>
+    <modules>
+        <module>kontrakter/politi/varetekt</module>
+    </modules>
 
-    </build>
     <profiles>
         <profile>
             <id>ossrh</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>no.esas</groupId>
-    <artifactId>kontrakter</artifactId>
+    <groupId>io.github.domstolene</groupId>
+    <artifactId>esas-kontrakter</artifactId>
     <version>${revision}</version>
     <packaging>jar</packaging>
     <description>Json-schemaer definert i ESAS-prosjektet</description>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>no.esas</groupId>
+    <artifactId>kontrakter</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <build>
+        <resources>
+            <resource>
+                <targetPath>esas/varetekt</targetPath>
+                <directory>kontrakter/politi/varetekt</directory>
+                <includes>
+                    <include>**/*.json</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
+</project>


### PR DESCRIPTION
Deployer artefakt som inneholder json-schema til github package registry (GPR). Deployer kun filer i `kontrakter/politi/varetekt` som er definert som en egen maven-modul, med parent øverst i repoet. Enkelt å utvide for nye skjema. Deploy er satt til å gjøre mot ossrh. 

Setter versjon i format "dato.kortGitHash". Litt for enkelthetens skyld, men også da det finnes versjonering i mappestrukturen siden jeg antar vi trenger å støtte flere versjoner i overgangsperioder, og det da føles litt kunstig med eks semver.