### PR TITLE
Opprydninger og formatering av begjaeringVaretekt

### DIFF
--- a/kontrakter/politi/varetekt/1.0/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/1.0/begjaeringVaretekt.schema.json
@@ -5,55 +5,105 @@
 
   "type": "object",
   "properties": {
-    "melding": {"const": "begjaeringVaretekt", "description": "Navnet på meldingen. Enkelt å se på en melding hvilken type det er."},
-    "forsendelse": {"$ref": "#/definitions/forsendelse", "description": "avsender og mottaker"},
-    "hovedStraffesaksnummer": {"type": "string", "description": "BL Saksbehandlersak er hovedsaken i et sakskompleks (som er 1 eller flere straffesaker)"},
-    "begjaeringVaretekt": {"$ref": "#/definitions/begjaeringVaretekt"},
-    "vedlegg": {"$ref": "#/definitions/vedlegg"}
+    "melding": {
+      "type": "string",
+      "const": "begjaeringVaretekt",
+      "description": "Navnet på meldingen. Enkelt å se på en melding hvilken type det er."
+    },
+    "forsendelse": {
+      "$ref": "#/definitions/forsendelse",
+      "description": "avsender og mottaker"
+    },
+    "hovedStraffesaksnummer": {
+      "type": "string",
+      "description": "BL Saksbehandlersak er hovedsaken i et sakskompleks (som er 1 eller flere straffesaker)"
+    },
+    "begjaeringVaretekt": {
+      "$ref": "#/definitions/begjaeringVaretekt"
+    },
+    "vedlegg": {
+      "$ref": "#/definitions/vedlegg"
+    }
   },
   "required": ["melding", "forsendelse", "hovedStraffesaksnummer", "begjaeringVaretekt", "vedlegg"],
   "additionalProperties": false,
 
-  
+
   "definitions": {
     "begjaeringVaretekt": {
-      "description": "Begjæringen med data som er nødvendig for avgjørelsen. Siktede og krav som skal avgjøres.",
       "type": "object",
+      "description": "Begjæringen med data som er nødvendig for avgjørelsen. Siktede og krav som skal avgjøres.",
       "properties": {
-        "kravId": {"type": "string"},
-        "siktet": {"$ref": "#/definitions/siktetInfo", "description": "Person som skal varetektsfengsles"},
-        "under18": {"type": "boolean", "description": "Siktede er under 18 år og skal fremstilles dagen etter pågripelse."},
-        "varetekt": {"$ref": "#/definitions/varetektInfo"},
-        "saksinformasjon": {"$ref": "#/definitions/saksinformasjon"}
+        "kravId": {
+          "type": "string"
+        },
+        "siktet": {
+          "$ref": "#/definitions/siktetInfo",
+          "description": "Person som skal varetektsfengsles"
+        },
+        "under18": {
+          "type": "boolean",
+          "description": "Siktede er under 18 år og skal fremstilles dagen etter pågripelse."
+        },
+        "varetekt": {
+          "$ref": "#/definitions/varetektInfo"
+        },
+        "saksinformasjon": {
+          "$ref": "#/definitions/saksinformasjon"
+        }
       },
       "required": ["kravId", "siktet", "varetekt", "saksinformasjon"],
       "additionalProperties": false
     },
     "vedlegg": {
-      "description": "Bekgrunsinformasjon (grunnlag) som retten trenger som dokumenter, informasjon om straffesaken (vitner, fornærmede), siktelse og dokumenter.",
       "type": "object",
+      "description": "Bekgrunsinformasjon (grunnlag) som retten trenger som dokumenter, informasjon om straffesaken (vitner, fornærmede), siktelse og dokumenter.",
       "properties": {
-        "siktelse": {"$ref": "#/definitions/siktelseTiltale"},
-        "straffesaker": {"type": "array", "items": {"$ref": "#/definitions/straffesakMedInvolverteSiktet"}, "minItems": 1},
-        "dokumenter": {"type": "array", "items": {"$ref": "#/definitions/dokument"}}
+        "siktelse": {
+          "$ref": "#/definitions/siktelseTiltale"
+        },
+        "straffesaker": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/straffesakMedInvolverteSiktet"
+          },
+          "minItems": 1
+        },
+        "dokumenter": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/dokument"
+          }
+        }
       },
       "required": ["straffesaker", "dokumenter"],
       "additionalProperties": false
     },
 
     "paastandVaretekt": {
-      "description": "Påtale sier hvor hvor lenge i varetekt og hvilke restriksjoner/isolasjonskrav som de ønsker",
       "type": "object",
+      "description": "Påtale sier hvor hvor lenge i varetekt og hvilke restriksjoner/isolasjonskrav som de ønsker",
       "required": ["fengsling", "restriksjoner", "isolasjon"],
       "additionalProperties": false,
       "properties": {
-        "fengsling": {"$ref": "#/definitions/fengsling"},
-        "restriksjoner": {"type": "array", "items": {"$ref": "#/definitions/restriksjonBegjaering"}},
-        "isolasjon": {"type": "array", "items": {"$ref": "#/definitions/isolasjonBegjaering"}}
+        "fengsling": {
+          "$ref": "#/definitions/fengsling"
+        },
+        "restriksjoner": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/restriksjonBegjaering"
+          }
+        },
+        "isolasjon": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/isolasjonBegjaering"}
+        }
       }
     },
 
     "saksinformasjon": {
+      "type": "object",
       "description": "Informasjon fengslingen",
       "properties": {
         "varetektsType": {"$ref": "#/definitions/varetektsType"},
@@ -62,19 +112,33 @@
           "type": "object",
           "description": "Hvis de tror hovedforhandling kommer før varetektsfengsling er ferdig",
             "properties": {
-              "beskrivelse": {"type": "string"},
-              "berammetDato": {"type": "string", "format": "date"}
+              "beskrivelse": {
+                "type": "string"
+              },
+              "berammetDato": {
+                "type": "string",
+                "format": "date"
+              }
             },
             "required": ["beskrivelse"],
             "additionalProperties": false
         },
-        "paagrepetTidspunkt": {"type": "string", "format": "date-time"},
+        "paagrepetTidspunkt": {
+          "type": "string",
+          "format": "date-time"
+        },
         "berammetFengslingsmoete": {
           "type": "object",
           "properties": {
-            "dato": {"type": "string", "format": "date"},
-            "tid": {"type": "string", "format": "time"},
-            "sted": {"type": "string"}
+            "dato": {
+              "type": "string", "format": "date"
+            },
+            "tid": {
+              "type": "string", "format": "time"
+            },
+            "sted": {
+              "type": "string"
+            }
           },
           "required": ["dato"],
           "additionalProperties": false
@@ -83,247 +147,379 @@
           "description": "Er det oppnevnt forsvarer og sendt dokumenter?",
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["VARSLET_DOK","IKKE_ONSKET_FORSVARER"]},
-            "beskrivelse": {"type": "string"}
+            "status": {
+              "type": "string",
+              "enum": ["VARSLET_DOK","IKKE_ONSKET_FORSVARER"]
+            },
+            "beskrivelse": {
+              "type": "string"
+            }
           },
           "required": ["status"],
           "additionalProperties": false
         },
-        "varsleBistandsadvokat": {"type":"string"},
-        "begrenseOffentlighet": {"type":"string","enum":["LUKKEDE_DOERER", "FORBUD_GJENGIVELSE"]},
-        "ansvarligPaatalejurist": {"$ref": "#/definitions/ansatt"},
-        "aktor": {"$ref": "#/definitions/ansatt"}
+        "varsleBistandsadvokat": {
+          "type":"string"
+        },
+        "begrenseOffentlighet": {
+          "type":"string",
+          "enum":["LUKKEDE_DOERER", "FORBUD_GJENGIVELSE"]
+        },
+        "ansvarligPaatalejurist": {
+          "$ref": "#/definitions/ansatt"
+        },
+        "aktor": {
+          "$ref": "#/definitions/ansatt"
+        }
       },
       "required": ["varetektsType", "paagrepetTidspunkt", "ansvarligPaatalejurist"],
       "additionalProperties": false
     },
 
     "fengsling": {
-      "description": "Hvor lenge i varetekt ",
       "type": "object",
+      "description": "Hvor lenge i varetekt ",
       "properties": {
-        "id": {"type": "string"},
-        "antallDager": {"type": "integer"}
+        "id": {
+          "type": "string"
+        },
+        "antallDager": {
+          "type": "integer"
+        }
       },
       "required": ["id", "antallDager"],
       "additionalProperties": false
     },
     "forlengelseInfo": {
+      "type": "object",
       "description": "Hvis det er en forlengelse så referer vi til forrige fengsling, trenger domstolene mer informasjon ?",
-      "typ": "object",
       "properties": {
-        "avgjoerelseId": {"type": "string", "description": "Domstolene sin nøkkel til den forrige fengslingskjennelsen"},
-        "beskrivelse": {"type": "string", "description": "Kanskje referanse til dokument etc"}
+        "avgjoerelseId": {
+          "type": "string",
+          "description": "Domstolene sin nøkkel til den forrige fengslingskjennelsen"
+        },
+        "beskrivelse": {
+          "type": "string",
+          "description": "Kanskje referanse til dokument etc"
+        }
       },
       "required": ["beskrivelse"],
       "additionalProperties": false
     },
     "siktetInfo": {
+      "type": "object",
       "properties": {
-        "person": {"$ref": "#/definitions/person"},
-        "forsvarer": {"$ref": "#/definitions/profesjonellPerson"},
-        "verger": {"type": "array", "items": {"$ref": "#/definitions/personEnkel"}, "description": "Verger hvis de er definert."}
+        "person": {
+          "$ref": "#/definitions/person"
+        },
+        "forsvarer": {
+          "$ref": "#/definitions/profesjonellPerson"
+        },
+        "verger": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personEnkel"
+          },
+          "description": "Verger hvis de er definert."
+        }
       },
       "required": ["person", "verger"],
       "additionalProperties": false
     },
     "varetektInfo": {
-      "description": "Varetekt type, dager, restriksjoner, isolasjon",
       "type": "object",
+      "description": "Varetekt type, dager, restriksjoner, isolasjon",
       "properties": {
-        "lovbud": {"$ref": "#/definitions/lovbudEnkel"},
-        "paastandVaretekt": {"$ref": "#/definitions/paastandVaretekt", "description": "Påtale sine ønsker for varetekt."},
-        "vilkaar": {"type": "array", "items": {"$ref": "#/definitions/vilkaar"}, "description": "Vilkårene listet enkeltvis. Disse er sammenstilt i lovbudStreng"}
+        "lovbud": {
+          "$ref": "#/definitions/lovbudEnkel"
+        },
+        "paastandVaretekt": {
+          "$ref": "#/definitions/paastandVaretekt",
+          "description": "Påtale sine ønsker for varetekt."
+        },
+        "vilkaar": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/vilkaar"
+          },
+          "description": "Vilkårene listet enkeltvis. Disse er sammenstilt i lovbudStreng"
+        }
       },
       "required": ["lovbud", "paastandVaretekt", "vilkaar"],
       "additionalProperties": false
     },
     "varetektsType": {
+      "type": "string",
       "description": "Vanlig, eller brudd på vilkår",
       "enum": [
         "VANLIG",
         "VILKAARSBRUDD"
-      ],
-      "type": "string"
+      ]
     },
     "vilkaarsType": {
+      "type": "string",
       "description": "Hvilket vilkår gjelder for varetektsfengslingen. 173 brukes ved vilkårsbrudd.",
       "enum": [
         "STRPL170A_FORHOLSMESSIGHET", "STRPL171_1_UNNDRAGELSESFARE", "STRPL171_2_BEVISFORSPILLELSE",
         "STRPL171_3_GJENTAGELSESFARE", "STRPL171_4_FYLDESTGJOERENDE_GRUNNER", "STRPL172_A_10_AAR",
         "STRPL172_B_GROV_VOLD",
         "STRPL173A_A_UNNDRAGELSESFARE_VILK","STRPL173A_B_HINDRE_VILK", "STRPL173A_C_BEGJAERT_SIKTEDE"
-      ],
-      "type": "string"
+      ]
     },
     "vilkaar": {
-      "description": "Et vilkår for varetektsfengsling",
       "type": "object",
+      "description": "Et vilkår for varetektsfengsling",
       "properties": {
-        "type": {"$ref": "#/definitions/vilkaarsType"},
-        "lovbudEnkel": {"$ref": "#/definitions/lovbudEnkel"}
+        "type": {
+          "$ref": "#/definitions/vilkaarsType"
+        },
+        "lovbudEnkel": {
+          "$ref": "#/definitions/lovbudEnkel"
+        }
       },
       "required": ["type", "lovbudEnkel"],
       "additionalProperties": false
-    },      
-
+    },
     "adresse": {
       "type": "object",
       "properties": {
         "adresselinjer": {
           "type": "array",
-          "items": {"type": "string","minLength": 1, "maxLength": 500},
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
           "minItems": 1,
           "maxItems": 4
         },
-        "postnummer": {"type": "string"},
-        "poststed": {"type": "string"},
-        "land": {"$ref": "#/definitions/land"}
+        "postnummer": {
+          "type": "string"
+        },
+        "poststed": {
+          "type": "string"
+        },
+        "land": {
+          "$ref": "#/definitions/land"
+        }
         },
       "required": ["adresselinjer"],
       "additionalProperties": false
     },
-	  "kodeverk": {
-		  "properties": {
-			"kode": {"type": "string"},
-			"navn": {"type": "string"}
-		  },
-		  "required": ["kode"],
-		  "additionalProperties": false
-	  },
-	  "kontaktInfo": {
-		  "properties": {
-			"epost": {"type": "string"},
- 			"telefon": {"type": "string"}
-		  },
-		  "additionalProperties": false
-	  },
-    "land": {
-      "description": "ISO-3166, Kosovo kommer",
+    "kodeverk": {
       "type": "object",
       "properties": {
-        "kode": {"type": "string", "pattern": "[A-Z]+", "minLength": 3, "maxLength": 3},
-        "navn": {"type": "string"}
+        "kode": {
+          "type": "string"
         },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["kode"],
+      "additionalProperties": false
+    },
+    "kontaktInfo": {
+      "type": "object",
+      "properties": {
+        "epost": {
+          "type": "string"
+        },
+        "telefon": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "land": {
+      "type": "object",
+      "description": "ISO-3166, Kosovo kommer",
+      "properties": {
+        "kode": {
+          "type": "string",
+          "pattern": "[A-Z]+",
+          "minLength": 3,
+          "maxLength": 3
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
       "required": ["kode"],
       "additionalProperties": false
     },
     "organisasjon": {
-      "description": "Organisasjon som kan sende eller motta JustisHub meldinger",
       "type": "object",
+      "description": "Organisasjon som kan sende eller motta JustisHub meldinger",
       "properties": {
-        "organisasjonsnummer": {"type": "string"},
-        "navn": {"type": "string"}
+        "organisasjonsnummer": {
+          "type": "string"
         },
+        "navn": {
+          "type": "string"
+        }
+      },
       "required": ["organisasjonsnummer","navn"],
       "additionalProperties": false
     },
-	  "ansatt": {
-      "description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
+    "ansatt": {
       "type": "object",
+      "description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
       "properties": {
-        "brukeridentifikasjon": {"type": "string"},
-        "tittel":  {"type": "string"},
-        "navn": {"$ref": "#/definitions/personnavn"},
-        "kontakt": {"$ref": "#/definitions/kontaktInfo"}
+        "brukeridentifikasjon": {
+          "type": "string"
+        },
+        "tittel":  {
+          "type": "string"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "kontakt": {
+          "$ref": "#/definitions/kontaktInfo"
+        }
       },
       "required": ["navn"],
       "additionalProperties": false
     },
-
-  "forsendelse": {
-		  "properties": {
-			"meldingsId": {"type": "string"},
-			"sendtTid": {"type": "string", "format": "date-time"},
-			"avsender": {"$ref": "#/definitions/avsender"},
-			"mottakerOrganisasjon": {"$ref": "#/definitions/organisasjon", "decription": "Domstol som skal være mottaker"},
-      "oensketRettssted": {"$ref": "#/definitions/organisasjon", "description": "Ønsket sted for rettsmøtet, f.eks. Brekstad i Trøndelag tingrett. Vil ikke bli implementert til å begynne med"}
-		  },
-		  "required": ["meldingsId", "avsender", "mottakerOrganisasjon", "sendtTid"],
-		  "additionalProperties": false
-	  },
-	  "avsender": {
-		  "properties": {
-			  "organisasjon": {"$ref": "#/definitions/organisasjon"},
-			  "saksbehandler": {"$ref": "#/definitions/ansatt", "descriptioin": "Person som trykker på send til domstolen."}
-		  },
-		  "required": ["organisasjon"],
-		  "additionalProperties": false
+    "forsendelse": {
+      "type": "object",
+      "properties": {
+        "meldingsId": {
+          "type": "string"
+        },
+        "sendtTid": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "avsender": {
+          "$ref": "#/definitions/avsender"
+        },
+        "mottakerOrganisasjon": {
+          "$ref": "#/definitions/organisasjon",
+          "decription": "Domstol som skal være mottaker"
+        },
+        "oensketRettssted": {
+          "$ref": "#/definitions/organisasjon",
+          "description": "Ønsket sted for rettsmøtet, f.eks. Brekstad i Trøndelag tingrett. Vil ikke bli implementert til å begynne med"
+        }
+      },
+      "required": ["meldingsId", "avsender", "mottakerOrganisasjon", "sendtTid"],
+      "additionalProperties": false
     },
-		"anke": {
+    "avsender": {
+      "type": "object",
+      "properties": {
+        "organisasjon": {
+          "$ref": "#/definitions/organisasjon"
+        },
+        "saksbehandler": {
+          "$ref": "#/definitions/ansatt",
+          "descriptioin": "Person som trykker på send til domstolen."
+        }
+      },
+      "required": ["organisasjon"],
+      "additionalProperties": false
+    },
+    "anke": {
+      "type": "object",
       "description": "Anke av fengsling/restriksjon/kjennelse",
-      "type": "object",
-      "required": ["anketAv", "oppsettendeVirkning"],
       "additionalProperties": false,
-			"properties": {				
-				
-				"anketDato": {"type": "string", "format": "date"},
-				"anketAv": {"$ref": "#/definitions/anketAvType"},
-				"oppsettendeVirkning": {"type": "boolean"}
-			}
-		},		
-		"anketAvType": {
-			"description": "Hvem av partene har anket",
-			"enum": ["SIKTET","FORSVARER", "AKTOR"],
-			"type": "string"
-		},
-
+      "properties": {
+        "anketDato": {
+          "type": "string",
+          "format": "date"
+        },
+        "anketAv": {
+          "$ref": "#/definitions/anketAvType"
+        },
+        "oppsettendeVirkning": {
+          "type": "boolean"
+        }
+      },
+      "required": ["anketAv", "oppsettendeVirkning"]
+    },
+    "anketAvType": {
+      "type": "string",
+      "description": "Hvem av partene har anket",
+      "enum": ["SIKTET","FORSVARER", "AKTOR"]
+    },
     "avgjoerelseDomstol": {
+      "type": "object",
       "description": "Kjennelse(r) fra retten, etter anke kan antagelig flere retter være involvert og da må vi endre denne",
-      "type": "object",
-      "required": ["kjennelse"],
       "additionalProperties": false,
       "properties": {
-        "merknad": {"type": "string"},
-        "kjennelse": {"type": "string"}
-      }
+        "merknad": {
+          "type": "string"
+        },
+        "kjennelse": {
+          "type": "string"
+        }
+      },
+      "required": ["kjennelse"]
     },
-
     "fengslingKjennelse": {
-      "description": "Fengsling som en del av kjennelsen, uten datoer så er det ikke noe fengsel",
       "type": "object",
-      "required": ["fengsling", "domstol"],
+      "description": "Fengsling som en del av kjennelsen, uten datoer så er det ikke noe fengsel",
       "additionalProperties": false,
       "properties": {
-        "domstol": {"$ref": "#/definitions/organisasjon"},
-        "avsagtDato": {"type": "string", "format": "date"},
-        "fengsling": {"$ref": "#/definitions/fengsling"},
-        "anke": {"$ref": "#/definitions/anke"}
-      }
+        "domstol": {
+          "$ref": "#/definitions/organisasjon"
+        },
+        "avsagtDato": {
+          "type": "string",
+          "format": "date"
+        },
+        "fengsling": {
+          "$ref": "#/definitions/fengsling"
+        },
+        "anke": {
+          "$ref": "#/definitions/anke"
+        }
+      },
+      "required": ["fengsling", "domstol"],
     },
-
     "isolasjonBegjaering": {
       "type": "object",
-      "required": ["id","isolasjonsType","lovbudEnkel","periode"],
       "additionalProperties": false,
       "properties": {
-        "id": {"type": "string"},
-        "isolasjonsType": {"$ref": "#/definitions/isolasjonsType"},
-        "lovbudEnkel": {"$ref": "#/definitions/lovbudEnkel"},
-        "periode": {"$ref": "#/definitions/periodeStartAntall"}
-      }
+        "id": {
+          "type": "string"
+        },
+        "isolasjonsType": {
+          "$ref": "#/definitions/isolasjonsType"
+        },
+        "lovbudEnkel": {
+          "$ref": "#/definitions/lovbudEnkel"
+        },
+        "periode": {
+          "$ref": "#/definitions/periodeStartAntall"
+        }
+      },
+      "required": ["id","isolasjonsType","lovbudEnkel","periode"]
     },
-
     "isolasjonsType": {
+      "type": "string",
       "description": "Liste over de ulike isolasjonstyper",
       "enum": [
         "FULL_ISOLASJON",
         "DELVIS_ISOLASJON"
-      ],
-      "type": "string"
+      ]
     },
-
     "periodeStartAntall": {
-      "description": "Periode for fensling eller restriksjon, bruker ikke å spesifisere startdato, derfor lengde og antall dager inn i fengslingen for restriksjoner",
       "type": "object",
+      "description": "Periode for fensling eller restriksjon, bruker ikke å spesifisere startdato, derfor lengde og antall dager inn i fengslingen for restriksjoner",
       "required": ["startDag","antallDager"],
       "additionalProperties": false,
       "properties": {
-        "startDag": {"type": "integer"},
-        "antallDager": {"type": "integer"}
+        "startDag": {
+          "type": "integer"
+        },
+        "antallDager": {
+          "type": "integer"
+        }
       }
     },
-
     "restriksjonBegjaering": {
       "type": "object",
       "required": [
@@ -334,326 +530,521 @@
       ],
       "additionalProperties": false,
       "properties": {
-        "id": {"type": "string"},
-        "restriksjonsType": {"$ref": "#/definitions/restriksjonsType"},
-        "lovbudEnkel": {"$ref": "#/definitions/lovbudEnkel"},
-        "periode": {"$ref": "#/definitions/periodeStartAntall"}
+        "id": {
+          "type": "string"
+        },
+        "restriksjonsType": {
+          "$ref": "#/definitions/restriksjonsType"
+        },
+        "lovbudEnkel": {
+          "$ref": "#/definitions/lovbudEnkel"
+        },
+        "periode": {
+          "$ref": "#/definitions/periodeStartAntall"
+        }
       }
     },
-
     "restriksjonsType": {
+      "type": "string",
       "description": "Liste over de ulike restriksjonene",
       "enum": [
         "BREV_OG_BESOEKSFORBUD",
         "BREV_OG_BESOEKSKONTROLL",
         "MEDIEFORBUD",
         "ANNET"
-      ],
-      "type": "string"
+      ]
     },
-
     "lovbudFull": {
+      "type": "object",
       "description": "Lovvbudreferanse med gjengivelse og strafferamme",
       "properties": {
-        "lovbudId": {"type": "string"},
-        "lovbudStreng": {"type": "string"},
-        "gjengivelse": {"type": "string"},
-        "hjemmel": {"type": "array", "items": {"$ref": "#/definitions/lovreferanse"},"minItems": 1},
-        "strafferamme": {"type": "integer", "description": "Antall måneder"}
+        "lovbudId": {
+          "type": "string"
+        },
+        "lovbudStreng": {
+          "type": "string"
+        },
+        "gjengivelse": {
+          "type": "string"
+        },
+        "hjemmel": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/lovreferanse"
+          },
+          "minItems": 1
+        },
+        "strafferamme": {
+          "type": "integer",
+          "description": "Antall måneder"
+        }
       },
       "required": ["lovbudStreng", "gjengivelse"],
       "additionalProperties": false
     },
-
     "lovbudGjengivelse": {
+      "type": "object",
       "description": "Lovvbudreferanse med gjengivelse",
       "properties": {
-        "lovbudId": {"type": "string"},
-        "lovbudStreng": {"type": "string"},
-        "gjengivelse": {"type": "string"}
+        "lovbudId": {
+          "type": "string"
+        },
+        "lovbudStreng": {
+          "type": "string"
+        },
+        "gjengivelse": {
+          "type": "string"
+        }
       },
       "required": ["lovbudStreng", "gjengivelse"],
       "additionalProperties": false
     },
-
     "lovbudEnkel": {
+      "type": "object",
       "description": "Enkel lovbudreferanse kun lovbudstreng",
       "properties": {
-        "lovbudId": {"type": "string"},
-        "lovbudStreng": {"type": "string"}
+        "lovbudId": {
+          "type": "string"
+        },
+        "lovbudStreng": {
+          "type": "string"
+        }
       },
       "required": ["lovbudStreng"],
       "additionalProperties": false
     },
     "lovreferanse": {
+      "type": "object",
       "description": "Eksakt referanse inn i spesifikk lov, paragraf, ledd osv.",
       "properties": {
-        "rettskilde": {"$ref": "#/definitions/kodeverk"},
-        "lovreferanse": {"type": "array", "items": {"$ref": "#/definitions/lovreferanseElement"},"minItems": 1}
+        "rettskilde": {
+          "$ref": "#/definitions/kodeverk"
+        },
+        "lovreferanse": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/lovreferanseElement"
+          },
+          "minItems": 1
+        }
       },
       "required": ["rettskilde", "lovreferanse"],
       "additionalProperties": false
     },
-
     "lovreferanseElement": {
+      "type": "object",
       "description": "Referanse til paragraf, ledd osv, type kan bli enum som er utvidbar .. PARAGRAG, LEDD, STRAFFALTERNATIV",
       "properties": {
-        "type": {"type": "string"},
-        "verdi": {"type": "string"}
+        "type": {
+          "type": "string"
+        },
+        "verdi": {
+          "type": "string"
+        }
       },
       "required": ["type", "verdi"],
       "additionalProperties": false
     },
-
     "adresseGradering": {
+      "type": "string",
       "description": "Samme enum som folkeregisteret, ugradert hvis den ikke er gradert",
-      "type": "string", "enum": ["KLIENT_ADRESSE","FORTROLIG","STRENGT_FORTROLIG"]},
-
+      "enum": ["KLIENT_ADRESSE","FORTROLIG","STRENGT_FORTROLIG"]
+    },
     "personnavn": {
       "type": "object",
       "properties": {
-        "fornavn": {"type": "string"},
-        "mellomnavn": {"type": "string"},
-        "etternavn": {"type": "string"}
+        "fornavn": {
+          "type": "string"
+        },
+        "mellomnavn": {
+          "type": "string"
+        },
+        "etternavn": {
+          "type": "string"
+        }
         },
       "required": ["etternavn"],
       "additionalProperties": false
     },
-
-    "foedselsnummer": {"type": "string", "pattern": "[0-9]+", "minLength": 11, "maxLength": 11},
-    "sspNummer": {"type": "string", "pattern": "[0-9]+", "minLength": 11, "maxLength": 11},
-    "dNummer": {"type": "string", "pattern": "[0-9]+", "minLength": 11, "maxLength": 11},
-
+    "foedselsnummer": {
+      "type": "string",
+      "pattern": "[0-9]+",
+      "minLength": 11,
+      "maxLength": 11
+    },
+    "sspNummer": {
+      "type": "string",
+      "pattern": "[0-9]+",
+      "minLength": 11,
+      "maxLength": 11
+    },
+    "dNummer": {
+      "type": "string",
+      "pattern": "[0-9]+",
+      "minLength": 11,
+      "maxLength": 11
+    },
     "personIdentifikator": {
-      "description": "Fødselsnummer, D-nummer eller SSP nummer",
       "type": "object",
+      "description": "Fødselsnummer, D-nummer eller SSP nummer",
       "properties": {
-        "foedselsnummer": {"$ref": "#/definitions/foedselsnummer"},
-        "sspNummer": {"$ref": "#/definitions/sspNummer"},
-        "dNummer": {"$ref": "#/definitions/dNummer"}
-      },     
+        "foedselsnummer": {
+          "$ref": "#/definitions/foedselsnummer"
+        },
+        "sspNummer": {
+          "$ref": "#/definitions/sspNummer"
+        },
+        "dNummer": {
+          "$ref": "#/definitions/dNummer"
+        }
+      },
       "oneOf": [
         {
           "properties": {
-            "foedselsnummer": {"$ref": "#/definitions/foedselsnummer"}
+            "foedselsnummer": {
+              "$ref": "#/definitions/foedselsnummer"
+            }
           },
           "required": ["foedselsnummer"],
           "additionalProperties": false
         },
         {
           "properties": {
-            "sspNummer": {"$ref": "#/definitions/sspNummer"}
+            "sspNummer": {
+              "$ref": "#/definitions/sspNummer"
+            }
           },
           "required": ["sspNummer"],
           "additionalProperties": false
         },
         {
           "properties": {
-            "dNummer": {"$ref": "#/definitions/dNummer"}
+            "dNummer": {
+              "$ref": "#/definitions/dNummer"
+            }
           },
           "required": ["dNummer"],
           "additionalProperties": false
         }
       ]
     },
-
     "foretak": {
-      "description": "Foretak/ organisasjon som er med i en straffesak som f.eks. fornærmet",
       "type": "object",
+      "description": "Foretak/ organisasjon som er med i en straffesak som f.eks. fornærmet",
       "properties": {
-        "internId": {"type": "string", "description": "unik id lokalt i meldingen, samme internId er samme foretak."},
-        "organisasjonsnummer": {"type": "string"},
-        "navn": {"type": "string"},
-        "adresse": {"$ref": "#/definitions/adresse"}
+        "internId": {
+          "type": "string",
+          "description": "unik id lokalt i meldingen, samme internId er samme foretak."
+        },
+        "organisasjonsnummer": {
+          "type": "string"
+        },
+        "navn": {
+          "type": "string"
+        },
+        "adresse": {
+          "$ref": "#/definitions/adresse"
+        }
         },
       "required": ["internId","navn"],
       "additionalProperties": false
     },
     "foretakEnkel": {
-      "description": "Foretak/ organisasjon som er med i en straffesak som f.eks. fornærmet",
       "type": "object",
+      "description": "Foretak/ organisasjon som er med i en straffesak som f.eks. fornærmet",
       "properties": {
-        "internId": {"type": "string", "description": "unik id lokalt i meldingen, samme internId er samme foretak."},
-        "organisasjonsnummer": {"type": "string"},
-        "navn": {"type": "string"}
+        "internId": {
+          "type": "string",
+          "description": "unik id lokalt i meldingen, samme internId er samme foretak."
+        },
+        "organisasjonsnummer": {
+          "type": "string"
+        },
+        "navn": {
+          "type": "string"
+        }
         },
       "required": ["internId","navn"],
       "additionalProperties": false
     },
-
     "kjoenn": {
+      "type": "string",
       "description": "Samme enum som folkeregisteret",
-      "type": "string", "enum": ["KVINNE","MANN"]},
-
+      "enum": ["KVINNE","MANN"]
+    },
     "personForetak": {
-      "description": "En siktet eller fornærmet kan være en person eller et foretak, denne typen er enten person eller foretak.",
       "type": "object",
+      "description": "En siktet eller fornærmet kan være en person eller et foretak, denne typen er enten person eller foretak.",
       "properties": {
-        "person": {"$ref": "#/definitions/person"},
-        "foretak": {"$ref": "#/definitions/foretak"}
+        "person": {
+          "$ref": "#/definitions/person"
+        },
+        "foretak": {
+          "$ref": "#/definitions/foretak"
+        }
       },
       "oneOf": [
         {
           "properties":{
-            "person": {"$ref": "#/definitions/person"}
+            "person": {
+              "$ref": "#/definitions/person"
+            }
           },
           "additionalProperties": false,
           "required": ["person"]
         },
         {
           "properties":{
-            "foretak": {"$ref": "#/definitions/foretak"}
+            "foretak": {
+              "$ref": "#/definitions/foretak"
+            }
           },
           "additionalProperties": false,
           "required": ["foretak"]
         }
       ]
     },
-
     "personForetakEnkel": {
-      "description": "En siktet eller fornærmet kan være en person eller et foretak, denne typen er enten person eller foretak.",
       "type": "object",
+      "description": "En siktet eller fornærmet kan være en person eller et foretak, denne typen er enten person eller foretak.",
       "properties": {
-        "personEnkel": {"$ref": "#/definitions/personEnkel"},
-        "foretakEnkel": {"$ref": "#/definitions/foretak"}
+        "personEnkel": {
+          "$ref": "#/definitions/personEnkel"
+        },
+        "foretakEnkel": {
+          "$ref": "#/definitions/foretak"
+        }
       },
       "oneOf": [
         {
           "properties":{
-            "personEnkel": {"$ref": "#/definitions/personEnkel"}
+            "personEnkel": {
+              "$ref": "#/definitions/personEnkel"
+            }
           },
           "required": ["personEnkel"],
           "additionalProperties": false
         },
         {
           "properties":{
-            "foretakEnkel": {"$ref": "#/definitions/foretak"}
+            "foretakEnkel": {
+              "$ref": "#/definitions/foretak"
+            }
           },
           "required": ["foretakEnkel"],
           "additionalProperties": false
         }
       ]
     },
-
     "personAdresse": {
-      "description": "Kan være graderte adresser",
       "type": "object",
+      "description": "Kan være graderte adresser",
       "properties": {
-        "gradering": {"$ref": "#/definitions/adresseGradering"},
-        "adresse": {"$ref": "#/definitions/adresse"}
+        "gradering": {
+          "$ref": "#/definitions/adresseGradering"
+        },
+        "adresse": {
+          "$ref": "#/definitions/adresse"
+        }
       },
       "required": ["adresse"],
       "additionalProperties": false
     },
-   
     "person": {
-      "description": "Person med alle nyttige data som fødselsnummer adresse osv., SSP nummer kun på siktede, tiltalte.",
       "type": "object",
+      "description": "Person med alle nyttige data som fødselsnummer adresse osv., SSP nummer kun på siktede, tiltalte.",
       "properties": {
-        "internId": {"type": "string", "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId"},
-        "navn": {"$ref": "#/definitions/personnavn"},
-        "foedselsdato": {"type": "string", "format": "date"},
-        "kjoenn": {"$ref": "#/definitions/kjoenn", "description": "Ukjent kjønn hvis denne ikke er med"},
-        "statsborgerskap": {"type": "array", "items": {"$ref": "#/definitions/land"}},
-        "identitetsnummer": {"$ref": "#/definitions/personIdentifikator", "description": "Fødselsnummer, D-nummer eller SSP nummer som er den i bruk"},
-        "tilleggsId": {"type": "array", "items": {"$ref": "#/definitions/personIdentifikator"}, "description": "Kan være SSP nummer hvis person har D-nummer, fremtidig historiske nummer?"},
-        "adresseGradering": {"$ref": "#/definitions/adresseGradering"},
-        "personAdresse": {"$ref": "#/definitions/personAdresse"}
+        "internId": {
+          "type": "string",
+          "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": {
+          "type": "string",
+          "format": "date"
+        },
+        "kjoenn": {
+          "$ref": "#/definitions/kjoenn",
+          "description": "Ukjent kjønn hvis denne ikke er med"
+        },
+        "statsborgerskap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/land"
+          }
+        },
+        "identitetsnummer": {
+          "$ref": "#/definitions/personIdentifikator",
+          "description": "Fødselsnummer, D-nummer eller SSP nummer som er den i bruk"
+        },
+        "tilleggsId": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personIdentifikator"
+          },
+          "description": "Kan være SSP nummer hvis person har D-nummer, fremtidig historiske nummer?"
+        },
+        "adresseGradering": {
+          "$ref": "#/definitions/adresseGradering"
+        },
+        "personAdresse": {
+          "$ref": "#/definitions/personAdresse"
+        }
       },
       "required": ["internId","navn","foedselsdato", "statsborgerskap", "tilleggsId"],
       "additionalProperties": false
     },
-
     "personEnkel": {
-      "description": "Kun navn og fødselsdato (hvis den finnes)",
       "type": "object",
+      "description": "Kun navn og fødselsdato (hvis den finnes)",
       "properties": {
-        "internId": {"type": "string", "description": "Intern som peker på samme person i en spesifikk melding"},
-        "navn": {"$ref": "#/definitions/personnavn"},
-        "foedselsdato": {"type": "string", "format": "date"}
+        "internId": {
+          "type": "string",
+          "description": "Intern som peker på samme person i en spesifikk melding"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": {
+          "type": "string",
+          "format": "date"
+        }
       },
       "required": ["internId","navn"],
       "additionalProperties": false
     },
-	  "profesjonellPerson": {
-      "description": "Advokater, tolker, sakkyndige vitner",
+    "profesjonellPerson": {
       "type": "object",
+      "description": "Advokater, tolker, sakkyndige vitner",
       "properties": {
-        "tittel":  {"type": "string"},
+        "tittel":  {
+          "type": "string"
+        },
         "navn": {
           "type": "object",
           "properties": {
-            "fornavn": {"type": "string"},
-            "mellomnavn": {"type": "string"},
-            "etternavn": {"type": "string"}
+            "fornavn": {
+              "type": "string"
             },
+            "mellomnavn": {
+              "type": "string"
+            },
+            "etternavn": {
+              "type": "string"
+            }
+          },
           "required": ["etternavn"],
           "additionalProperties": false
         },
-        "kontakt": {"$ref": "#/definitions/kontaktInfo"}
+        "kontakt": {
+          "$ref": "#/definitions/kontaktInfo"
+        }
       },
       "required": ["navn"],
       "additionalProperties": false
     },
-
     "basissak": {
-      "description": "Person eller foretak og straffesaksreferanse",
       "type": "object",
+      "description": "Person eller foretak og straffesaksreferanse",
       "properties": {
-        "straffesaksnummer": {"type": "string"},
-        "personForetakEnkel": {"$ref": "#/definitions/personForetakEnkel"}
+        "straffesaksnummer": {
+          "type": "string"
+        },
+        "personForetakEnkel": {
+          "$ref": "#/definitions/personForetakEnkel"
+        }
       },
       "required": ["straffesaksnummer", "personForetakEnkel"],
       "additionalProperties": false
     },
-
     "grunnlagBasisaker": {
-      "description": "Grunnlaget er beskrivelse og referanser til basissaker (rolle,sak)",
       "type": "object",
+      "description": "Grunnlaget er beskrivelse og referanser til basissaker (rolle,sak)",
       "properties": {
-        "bokstav": {"type": "string"},
-        "grunnlagstekst": {"type": "string"},
-        "basissaker": {"type": "array", "items": {"$ref": "#/definitions/basissak"}, "minItems": 1}
+        "bokstav": {
+          "type": "string"
+        },
+        "grunnlagstekst": {
+          "type": "string"
+        },
+        "basissaker": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/basissak"
+          },
+          "minItems": 1
+        }
       },
       "required": ["grunnlagstekst","basissaker"],
       "additionalProperties": false
     },
     "punktDetaljer": {
-      "description": "Lovbudreferanse, grunnlag med basissaker",
       "type": "object",
+      "description": "Lovbudreferanse, grunnlag med basissaker",
       "properties": {
-        "nummer": {"type": "string"},
-        "lovbud": {"type": "array", "items": {"$ref": "#/definitions/lovbudGjengivelse"},"minItems": 1,"maxItems": 2},
-        "grunnlag": {"type": "array", "items": {"$ref": "#/definitions/grunnlagBasisaker"}}
+        "nummer": {
+          "type": "string"
+        },
+        "lovbud": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/lovbudGjengivelse"
+          },
+          "minItems": 1,
+          "maxItems": 2
+        },
+        "grunnlag": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/grunnlagBasisaker"
+          }
+        }
       },
       "required": ["lovbud"],
       "additionalProperties": false
     },
-
     "punkt": {
-      "description": "Et tiltalepunkt med romertall hvis det er mer en ett punkt",
       "type": "object",
+      "description": "Et tiltalepunkt med romertall hvis det er mer en ett punkt",
       "properties": {
-        "nummer": {"type": "string"},
-        "prinsipalPunkt":{"$ref": "#/definitions/punktDetaljer"},
-        "subsidiaerPunkt":{"$ref": "#/definitions/punktDetaljer"}
+        "nummer": {
+          "type": "string"
+        },
+        "prinsipalPunkt":{
+          "$ref": "#/definitions/punktDetaljer"
+        },
+        "subsidiaerPunkt":{
+          "$ref": "#/definitions/punktDetaljer"
+        }
       },
       "required": ["prinsipalPunkt"],
       "additionalProperties": false
     },
     "siktelseTiltale": {
+      "type": "object",
       "description": "Strukturert siktelse/tiltale.",
       "properties": {
-        "siktelseDokument": {"$ref": "#/definitions/dokumentRef", "description": "Referanse til siktelsesdokumentet (PDF) som er vedlagt meldingen"},
-        "punkt": {"type": "array", "items": {"$ref": "#/definitions/punkt"}, "minItems": 1, "description": "Et siktelsespunkt, kan være flere straffbare forhold og personer (basissaker)"}
+        "siktelseDokument": {
+          "$ref": "#/definitions/dokumentRef",
+          "description": "Referanse til siktelsesdokumentet (PDF) som er vedlagt meldingen"
+        },
+        "punkt": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/punkt"
+          },
+          "minItems": 1,
+          "description": "Et siktelsespunkt, kan være flere straffbare forhold og personer (basissaker)"
+        }
       },
       "required": ["punkt"],
       "additionalProperties": false
     },
-
     "hendelse": {
-      "description": "Tid og sted for det straffbare forholdet",
       "type": "object",
+      "description": "Tid og sted for det straffbare forholdet",
       "required": [
         "gjerningstidspunktFra",
         "gjerningstidspunktTil",
@@ -661,74 +1052,131 @@
       ],
       "additionalProperties": false,
       "properties": {
-        "gjerningstidspunktFra": {"type": "string", "format": "date-time"},
-        "gjerningstidspunktTil": {"type": "string","format": "date-time"},
-        "gjerningssted": {"$ref": "#/definitions/adresse"}
+        "gjerningstidspunktFra": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "gjerningstidspunktTil": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "gjerningssted": {
+          "$ref": "#/definitions/adresse"
+        }
       }
     },
     "involverteStraffesak": {
       "description": "siktede, vitner og fornærmede",
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "siktet": {"$ref": "#/definitions/personEnkel"},
-          "medsiktede": {"type": "array", "items": {"$ref": "#/definitions/personForetak"}},
-          "fornaermede": {"type": "array", "items": {"$ref": "#/definitions/personForetak"}},
-          "vitne": {"type": "array", "items": {"$ref": "#/definitions/person"}}
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "siktet": {
+          "$ref": "#/definitions/personEnkel"
+        },
+        "medsiktede": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personForetak"
+          }
+        },
+        "fornaermede": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personForetak"
+          }
+        },
+        "vitne": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/person"
+          }
+        }
       },
       "required": ["medsiktede", "fornaermede", "vitne"]
     },
-
     "straffesakMedInvolverteSiktet": {
-	  "description": "Straffesak med involverte listet samt enkel versjon av siktede",
       "type": "object",
-      "required": ["straffesaksnummer","detaljer", "involverte"],
+      "description": "Straffesak med involverte listet samt enkel versjon av siktede",
       "additionalProperties": false,
       "properties": {
-        "straffesaksnummer": {"type": "string"},
-        "detaljer": {"$ref": "#/definitions/straffesakDetaljer"},
-        "involverte": {"$ref": "#/definitions/involverteStraffesak"}
-      }
+        "straffesaksnummer": {
+          "type": "string"
+        },
+        "detaljer": {
+          "$ref": "#/definitions/straffesakDetaljer"
+        },
+        "involverte": {
+          "$ref": "#/definitions/involverteStraffesak"
+        }
+      },
+      "required": ["straffesaksnummer","detaljer", "involverte"]
     },
     "straffesakDetaljer": {
-	  "description": "Detaljer rundt straffesaken",
       "type": "object",
-      "required": ["hendelse","statistikkgruppe"],
+      "description": "Detaljer rundt straffesaken",
       "additionalProperties": false,
       "properties": {
-        "hendelse": {"$ref": "#/definitions/hendelse"},
-        "statistikkgruppe": {"$ref": "#/definitions/kodeverk"},
-        "krimtype": {"$ref": "#/definitions/kodeverk"}
-      }
+        "hendelse": {
+          "$ref": "#/definitions/hendelse"
+        },
+        "statistikkgruppe": {
+          "$ref": "#/definitions/kodeverk"
+        },
+        "krimtype": {
+          "$ref": "#/definitions/kodeverk"
+        }
+      },
+      "required": ["hendelse","statistikkgruppe"]
     },
-
     "dokument": {
+      "type": "object",
       "description": "Dokument som oversendes på justishub",
       "properties": {
-        "internId": {"type": "string", "description": "Id for dokumentet internt i meldingen slik at det kan refereres til et bestemt dokument (dokumentRef)"},
-        "kategori": {"$ref": "#/definitions/kodeverk"},
-        "overskrift": {"type": "string"},
-        "skrevetDato": {"type": "string", "format": "date"},
-        "forsendelse": {"$ref": "#/definitions/dokumentForsendelse"}
+        "internId": {
+          "type": "string",
+          "description": "Id for dokumentet internt i meldingen slik at det kan refereres til et bestemt dokument (dokumentRef)"
+        },
+        "kategori": {
+          "$ref": "#/definitions/kodeverk"
+        },
+        "overskrift": {
+          "type": "string"
+        },
+        "skrevetDato": {
+          "type": "string",
+          "format": "date"
+        },
+        "forsendelse": {
+          "$ref": "#/definitions/dokumentForsendelse"
+        }
       },
       "required": ["overskrift", "forsendelse"],
       "additionalProperties": false
     },
-
     "dokumentForsendelse": {
+      "type": "object",
       "description": "Detaljer om lokasjon og type",
       "properties": {
-        "mimeType": {"type": "string"},
-        "uri": {"type": "string"},
-        "sjekksum": {"type": "string"}
+        "mimeType": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "sjekksum": {
+          "type": "string"
+        }
       },
       "required": ["mimeType", "uri", "sjekksum"],
       "additionalProperties": false
     },
     "dokumentRef": {
+      "type": "object",
       "description": "Referanse internt i melding til dokumenter i dokumentlisten",
       "properties": {
-        "internId": {"type": "string"}
+        "internId": {
+          "type": "string"
+        }
       },
       "required": ["internId"],
       "additionalProperties": false

--- a/kontrakter/politi/varetekt/1.0/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/1.0/begjaeringVaretekt.schema.json
@@ -28,7 +28,6 @@
   "required": ["melding", "forsendelse", "hovedStraffesaksnummer", "begjaeringVaretekt", "vedlegg"],
   "additionalProperties": false,
 
-
   "definitions": {
     "begjaeringVaretekt": {
       "type": "object",
@@ -477,7 +476,7 @@
           "$ref": "#/definitions/anke"
         }
       },
-      "required": ["fengsling", "domstol"],
+      "required": ["fengsling", "domstol"]
     },
     "isolasjonBegjaering": {
       "type": "object",
@@ -1183,4 +1182,3 @@
     }
   }
 }
-


### PR DESCRIPTION
* Endel objekter manglet `"type": "object"`, som gjorde at enkelte generatorer slet med å bestemme typen til referanser.
* Har fikset formatering stort sett over alt. Bør vurdere å gå over til `prettier` eller lignende.