### PR TITLE
STRAFF2-434 Flere forenklinger i vartekts-kjennelse

### DIFF
--- a/kontrakter/da/varetekt/1.0/KjennelseVaretekt.schema.json
+++ b/kontrakter/da/varetekt/1.0/KjennelseVaretekt.schema.json
@@ -93,10 +93,6 @@
           "type": "string",
           "description": "Kravid som opprettes i politiet"
         },
-        "kravType": {
-          "type": "string",
-          "$comment": "Burde dette vært en enum i stedet? Eks: FHVaretekt"
-        },
         "restriksjoner": {
           "type": "array",
           "items": { "$ref": "#/definitions/restriksjon" }
@@ -107,13 +103,16 @@
         },
         "fengsling": {
           "$ref": "#/definitions/fengsling"
+        },
+        "anke": {
+          "$ref": "#/definitions/anke",
+          "description": "Settes kun dersom hele eller deler av avgjørelsen ankes før kjennelsen sendes til påtale"
         }
       },
       "required": [
         "avgjoerelseId",
         "avsagtDato",
         "kravid",
-        "kravType",
         "fengsling",
         "restriksjoner",
         "isolasjonsKrav"
@@ -142,17 +141,9 @@
         "merknad": {
           "type": "string",
           "description": "Merknad til fengslingen"
-        },
-        "anke": {
-          "$ref": "#/definitions/anke",
-          "description": "Settes kun dersom fengslingen ankes før kjennelsen sendes til påtale"
-        },
-        "tattTilFoelge": {
-          "type": "boolean",
-          "description": "Settes til true dersom det blir fengsling"
         }
       },
-      "required": ["fengslingsId", "tattTilFoelge"],
+      "required": ["fengslingsId"],
       "type": "object",
       "additionalProperties": false
     },
@@ -172,20 +163,9 @@
         "tilDato": {
           "description": "Om begjæringen ikke tas til følge skal dette feltet settes til null",
           "$ref": "#/definitions/dato"
-        },
-        "lovbud": {
-          "$ref": "#/definitions/lovbud"
-        },
-        "anke": {
-          "$ref": "#/definitions/anke",
-          "description": "Settes kun dersom restrikjsonen ankes før kjennelsen sendes til påtale"
-        },
-        "tattTilFoelge": {
-          "type": "boolean",
-          "description": "Settes til true dersom denne restriksjonstypen er begjært og det blir en kjennelse på den"
         }
       },
-      "required": ["restriksjonsId", "tattTilFoelge"],
+      "required": ["restriksjonsId", "restriksjonsType"],
       "type": "object",
       "additionalProperties": false
     },
@@ -205,31 +185,15 @@
         "tilDato": {
           "$ref": "#/definitions/dato",
           "description": "Om begjæringen ikke tas til følge skal dette feltet settes til null"
-        },
-        "lovbud": {
-          "$ref": "#/definitions/lovbud",
-          "$comment": "Trenger vi dette for isolasjon??"
-        },
-        "anke": {
-          "$ref": "#/definitions/anke",
-          "description": "Settes kun dersom isolasjonen ankes før kjennelsen sendes til påtale"
-        },
-        "tattTilFoelge": {
-          "type": "boolean",
-          "description": "Settes til true dersom denne isolasjonstypen er begjært og det blir kjennelse på den"
         }
       },
-      "required": ["isolasjonsId", "tattTilFoelge"],
+      "required": ["isolasjonsId", "isolasjonsType"],
       "type": "object",
       "additionalProperties": false
     },
 
     "lovbud": {
       "properties": {
-        "lovbudsId": {
-          "type": "string",
-          "description": "Politiets interne lovbudsnummer. Blank om det er endret i domstolen eller ikke fått fra politi"
-        },
         "lovbudStreng": {
           "type": "string"
         }
@@ -243,14 +207,11 @@
         "anketDato": {
           "$ref": "#/definitions/dato"
         },
-        "anketAv": {
-          "$ref": "#/definitions/anketAvType"
-        },
         "oppsettendeVirkning": {
           "type": "boolean"
         }
       },
-      "required": ["anketDato", "anketAv"],
+      "required": ["anketDato"],
       "type": "object",
       "additionalProperties": false
     },
@@ -266,11 +227,6 @@
     "isolasjonsType": {
       "description": "Liste over de ulike isolasjonstyper",
       "enum": ["FULL", "DELVIS"],
-      "type": "string"
-    },
-    "anketAvType": {
-      "description": "Liste over alle som kan anke",
-      "enum": ["SIKTET", "AKTOR"],
       "type": "string"
     },
     "forsendelse": {

--- a/kontrakter/da/varetekt/1.0/eksempelfiler/eksempel_kjennelseVaretektsfengsling.json
+++ b/kontrakter/da/varetekt/1.0/eksempelfiler/eksempel_kjennelseVaretektsfengsling.json
@@ -76,32 +76,18 @@
       "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
       "avsagtDato": "2022-07-05",
       "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
-      "kravType": "Fengsling {debug: Riktig?? FHFengsling}",
       "restriksjoner": [
         {
           "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
           "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
           "fraDato": "2022-07-06",
-          "tilDato": "2022-07-20",
-          "lovbud": {
-            "lovbudStreng": "Strpl. § 186, 2.ledd 1.pkt."
-          },
-          "anke": {
-            "anketDato": "2022-07-06",
-            "anketAv": "SIKTET",
-            "oppsettendeVirkning": false
-          },
-          "tattTilFoelge": true
+          "tilDato": "2022-07-20"          
         },
         {
           "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
           "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
           "fraDato": "2022-07-21",
-          "tilDato": "2022-08-06",
-          "lovbud": {
-            "lovbudStreng": "Strpl. § 186, 2.ledd 1.pkt."
-          },
-          "tattTilFoelge": true
+          "tilDato": "2022-08-06"
         }
       ],
       "isolasjonsKrav": [
@@ -109,16 +95,7 @@
           "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
           "isolasjonsType": "FULL",
           "fraDato": "2022-07-06",
-          "tilDato": "2022-08-06",
-          "lovbud": {
-            "lovbudStreng": "Strpl. § 186a"
-          },
-          "anke": {
-            "anketDato": "2022-07-06",
-            "anketAv": "SIKTET",
-            "oppsettendeVirkning": false
-          },
-          "tattTilFoelge": true
+          "tilDato": "2022-08-06"
         }
       ],
       "fengsling": {
@@ -129,13 +106,11 @@
         "lovbud": {
           "lovbudStreng": "strpl § 184, jf. § 185, jf. § 171 nr. 2"
         },
-        "merknad": "Kiwi må i varetekt så fort som fy",
-        "anke": {
-          "anketDato": "2022-07-06",
-          "anketAv": "SIKTET",
-          "oppsettendeVirkning": false
-        },
-        "tattTilFoelge": true
+        "merknad": "Kiwi må i varetekt så fort som fy"
+      },
+      "anke": {
+        "anketDato": "2022-07-06",
+        "oppsettendeVirkning": false
       }
     }
   }

--- a/kontrakter/da/varetekt/1.0/eksempelfiler/eksempel_kjennelseVaretektsfengsling_ingen_fengsling_anket.json
+++ b/kontrakter/da/varetekt/1.0/eksempelfiler/eksempel_kjennelseVaretektsfengsling_ingen_fengsling_anket.json
@@ -75,17 +75,14 @@
       "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
       "avsagtDato": "2022-07-05",
       "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
-      "kravType": "Fengsling {debug: Riktig?? FHFengsling}",
       "restriksjoner": [],
       "isolasjonsKrav": [],
       "fengsling": {
-        "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888",
-        "anke": {
-          "anketDato": "2022-07-06",
-          "anketAv": "AKTOR",
-          "oppsettendeVirkning": true
-        },
-        "tattTilFoelge": false
+        "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888"
+      },
+      "anke": {
+        "anketDato": "2022-07-06",
+        "oppsettendeVirkning": true
       }
     }
   }

--- a/kontrakter/da/varetekt/1.0/eksempelfiler/eksempel_kjennelseVaretektsfengsling_isolasjon.json
+++ b/kontrakter/da/varetekt/1.0/eksempelfiler/eksempel_kjennelseVaretektsfengsling_isolasjon.json
@@ -74,7 +74,6 @@
     "avgjoerelse": {
       "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
       "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
-      "kravType": "Fengsling {debug: Riktig?? FHFengsling}",
       "avsagtDato": "2022-07-05",
       "restriksjoner": [],
       "isolasjonsKrav": [
@@ -82,16 +81,7 @@
           "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
           "isolasjonsType": "FULL",
           "fraDato": "2022-07-06",
-          "tilDato": "2022-08-06",
-          "lovbud": {
-            "lovbudStreng": "Strpl. § 186a"
-          },
-          "anke": {
-            "anketDato": "2022-07-06",
-            "anketAv": "SIKTET",
-            "oppsettendeVirkning": false
-          },
-          "tattTilFoelge": true
+          "tilDato": "2022-08-06"
         }
       ],
       "fengsling": {
@@ -102,13 +92,11 @@
         "lovbud": {
           "lovbudStreng": "strpl § 184, jf. § 185, jf. § 171 nr. 2"
         },
-        "merknad": "Kiwi må i varetekt så fort som fy",
-        "anke": {
-          "anketDato": "2022-07-06",
-          "anketAv": "SIKTET",
-          "oppsettendeVirkning": false
-        },
-        "tattTilFoelge": true
+        "merknad": "Kiwi må i varetekt så fort som fy"
+      },
+      "anke": {
+        "anketDato": "2022-07-06",
+        "oppsettendeVirkning": false
       }
     }
   }

--- a/kontrakter/da/varetekt/1.0/eksempelfiler/eksempel_kjennelseVaretektsfengsling_restriksjoner.json
+++ b/kontrakter/da/varetekt/1.0/eksempelfiler/eksempel_kjennelseVaretektsfengsling_restriksjoner.json
@@ -75,32 +75,18 @@
       "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
       "avsagtDato": "2022-07-05",
       "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
-      "kravType": "Fengsling {debug: Riktig?? FHFengsling}",
       "restriksjoner": [
         {
           "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
           "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
           "fraDato": "2022-07-06",
-          "tilDato": "2022-07-20",
-          "lovbud": {
-            "lovbudStreng": "Strpl. § 186, 2.ledd 1.pkt."
-          },
-          "anke": {
-            "anketDato": "2022-07-06",
-            "anketAv": "SIKTET",
-            "oppsettendeVirkning": false
-          },
-          "tattTilFoelge": true
+          "tilDato": "2022-07-20"
         },
         {
           "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
           "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
           "fraDato": "2022-07-21",
-          "tilDato": "2022-08-06",
-          "lovbud": {
-            "lovbudStreng": "Strpl. § 186, 2.ledd 1.pkt."
-          },
-          "tattTilFoelge": true
+          "tilDato": "2022-08-06"
         }
       ],
       "isolasjonsKrav": [],
@@ -112,13 +98,7 @@
         "lovbud": {
           "lovbudStreng": "strpl § 184, jf. § 185, jf. § 171 nr. 2"
         },
-        "merknad": "Kiwi må i varetekt så fort som fy",
-        "anke": {
-          "anketDato": "2022-07-06",
-          "anketAv": "SIKTET",
-          "oppsettendeVirkning": false
-        },
-        "tattTilFoelge": true
+        "merknad": "Kiwi må i varetekt så fort som fy"
       }
     }
   }


### PR DESCRIPTION
Vi gjør noen flere forenklinger i varetektkjennelse kontrakten:

- Flytt anke/oppsettenendevirkning fra fengsling/restriksjon/isolasjon til avgjørelse-definisjonen
- Fjern lovbud-id (politiets interne lovbuds-nummer) fra lovbud-definisjonen
- Fjern lovbud fra restriksjon og isolasjon
- Ta bort kravtype fra kjennelsen
- Ta bort tattTilFølge igjen. (Denne er ikke lenger relevant når politiet ikke sender med id på fengsling/restriksjon/isolasjon)