### PR TITLE
ESAS-349 fjerne message name fra oppdaterVaretekt meldingen til KDI

### DIFF
--- a/kontrakter/politi/oppdatervaretekt/1.0/eksempelfiler/oppdaterVaretekt-kjennelse.json
+++ b/kontrakter/politi/oppdatervaretekt/1.0/eksempelfiler/oppdaterVaretekt-kjennelse.json
@@ -1,5 +1,4 @@
 {
-  "melding": "OPPDATER_VARETEKT",
   "forsendelse": {
     "meldingsId": "607AC26F-E3C3-4241-AE76-8389B7715968",
     "sendtTid": "2022-11-03T10:19:57+02:00",

--- a/kontrakter/politi/oppdatervaretekt/1.0/eksempelfiler/oppdaterVaretekt-paatale.json
+++ b/kontrakter/politi/oppdatervaretekt/1.0/eksempelfiler/oppdaterVaretekt-paatale.json
@@ -1,5 +1,4 @@
 {
-  "melding": "OPPDATER_VARETEKT",
   "forsendelse": {
     "meldingsId": "090388AB-8B5E-47E7-9763-A7EB852823F4",
     "sendtTid": "2022-11-03T10:19:59+02:00",

--- a/kontrakter/politi/oppdatervaretekt/1.0/oppdaterVaretekt.schema.json
+++ b/kontrakter/politi/oppdatervaretekt/1.0/oppdaterVaretekt.schema.json
@@ -4,11 +4,6 @@
   "description": "Kjennelse fra domstolen eller oppdatering av restriksjoner/isolasjon fra påtale",
   "type": "object",
   "properties": {
-    "melding": {
-      "type": "string",
-      "const": "OPPDATER_VARETEKT",
-      "description": "Navnet på meldingen. Enkelt å se på en melding hvilken type det er."
-    },
     "forsendelse": {
       "$ref": "#/definitions/forsendelse",
       "description": "avsender og mottaker"
@@ -39,7 +34,6 @@
     }
   },
   "required": [
-    "melding",
     "forsendelse",
     "hovedStraffesaksnummer",
     "personIVaretekt",

--- a/kontrakter/politi/oppdatervaretekt/changelog.md
+++ b/kontrakter/politi/oppdatervaretekt/changelog.md
@@ -1,5 +1,9 @@
 # oppdaterinv av varetekt endringer
 
+### message name skal til Header
+Fjernet message fra melding og eksempler.  
+Lagt til informasjon i [readme.md](readme.md)
 
-### 21.04.2023
+### Omorganisering til like typer
+21.04.2023
 Omorganisering slik at typer er like over alle meldinger.

--- a/kontrakter/politi/oppdatervaretekt/readme.md
+++ b/kontrakter/politi/oppdatervaretekt/readme.md
@@ -1,6 +1,11 @@
 # Oppdatering av varetekt
 Oppdatering av varetekt når kjennelsen kommer eller når påtale letter på restriksjoner/isolasjon.
 
+## Headere forsendelse justisHub
+SchmaName=OPPDATER_VARETEKT  
+SchemaVersion=1.0  
+[RFC](../../../rfc/MessageName-header.md)
+
 Versjon 1.0 er første versjon som vi skal i produksjon med.
 * [JSON Schema](1.0/oppdaterVaretekt.schema.json)
 * [Eksempler](1.0/eksempelfiler/)


### PR DESCRIPTION
Fjernet messag fra meldingen oppdaterVaretekt som avklart og oppdatert readme.md filen med header informasjon.