### PR TITLE
Feature/oppdater varetekt splitt

### DIFF
--- a/kontrakter/politi/bestillvaretektsplass/1.0/bestillingAvVaretektsplass.schema.json
+++ b/kontrakter/politi/bestillvaretektsplass/1.0/bestillingAvVaretektsplass.schema.json
@@ -4,11 +4,6 @@
   "description": "Bestilling av varetektsplass fra påtale til fengsel KDI. Schema versjon 2020-12",
   "type": "object",
   "properties": {
-    "melding": {
-      "type": "string",
-      "const": "BESTILLING_VARETEKTSPLASS",
-      "description": "Navnet på meldingen. Enkelt å se på en melding hvilken type det er."
-    },
     "forsendelse": {
       "$ref": "#/definitions/forsendelse",
       "description": "avsender og mottaker"
@@ -35,7 +30,6 @@
     }
   },
   "required": [
-    "melding",
     "forsendelse",
     "hovedStraffesaksnummer",
     "bestillingAvVaretektsplassId",
@@ -147,9 +141,8 @@
         "kategori": { "$ref": "#/definitions/kodeverk" },
         "overskrift": { "type": "string" },
         "skrevetDato": {
-          "description": "Dato",
           "type": "string",
-          "format": "date-time"
+          "format": "date"
         },
         "forsendelse": { "$ref": "#/definitions/dokumentForsendelse" }
       },
@@ -175,14 +168,14 @@
       "properties": {
         "lovbudEnkel": { "$ref": "#/definitions/lovbudEnkel" },
         "fraDato": {
-          "description": "Dato, som domstolene spesifiserer",
+          "description": "Dato som domstolene spesifiserer",
           "type": "string",
-          "format": "date-time"
+          "format": "date"
         },
         "tilDato": {
-          "description": "Dato, som domstolene spesifiserer",
+          "description": "Dato som domstolene spesifiserer",
           "type": "string",
-          "format": "date-time"
+          "format": "date"
         }
       }
     },
@@ -338,7 +331,7 @@
       "additionalProperties": false
     },
     "restriksjon": {
-      "description": "Basis restriksjon med til og fra dato",
+      "description": "Basis restriksjon",
       "type": "object",
       "required": ["restriksjonsType"],
       "additionalProperties": false,
@@ -678,9 +671,8 @@
           "$ref": "#/definitions/personnavn"
         },
         "foedselsdato": {
-          "description": "Dato",
           "type": "string",
-          "format": "date-time"
+          "format": "date"
         },
         "kjoenn": {
           "description": "Ukjent kjønn hvis denne ikke er med",
@@ -741,8 +733,7 @@
         },
         "foedselsdato": {
           "type": "string",
-          "description": "Dato",
-          "format": "date-time"
+          "format": "date"
         }
       },
       "required": ["internId", "navn"],

--- a/kontrakter/politi/bestillvaretektsplass/1.0/eksempelfiler/bestillingAvVaretektsplass-eksempel-1.json
+++ b/kontrakter/politi/bestillvaretektsplass/1.0/eksempelfiler/bestillingAvVaretektsplass-eksempel-1.json
@@ -1,5 +1,4 @@
 {
-  "melding": "BESTILLING_VARETEKTSPLASS",
   "forsendelse": {
     "meldingsId": "C5E8E429-2B8E-48A9-A9D3-FDAA5F9BE5",
     "sendtTid": "2022-11-03T10:19:55+02:00",
@@ -37,7 +36,7 @@
       },
       "tilleggsId": [],
       "kjoenn": "MANN",
-      "foedselsdato": "1963-04-14T00:00:00",
+      "foedselsdato": "1963-04-14",
       "statsborgerskap": [
         {
           "kode": "NOR",
@@ -98,7 +97,7 @@
               "fornavn": "Morsom",
               "etternavn": "KIWI"
             },
-            "foedselsdato": "1963-04-14T00:00:00"
+            "foedselsdato": "1963-04-14"
           },
           "medsiktede": [
             {
@@ -110,7 +109,7 @@
                 },
                 "tilleggsId": [],
                 "kjoenn": "MANN",
-                "foedselsdato": "1975-12-12T00:00:00",
+                "foedselsdato": "1975-12-12",
                 "statsborgerskap": [
                   {
                     "kode": "NOR",
@@ -132,7 +131,7 @@
                 },
                 "tilleggsId": [],
                 "kjoenn": "MANN",
-                "foedselsdato": "1970-07-19T00:00:00",
+                "foedselsdato": "1970-07-19",
                 "statsborgerskap": [
                   {
                     "kode": "NOR",
@@ -170,7 +169,7 @@
                 },
                 "tilleggsId": [],
                 "kjoenn": "KVINNE",
-                "foedselsdato": "1974-10-31T00:00:00",
+                "foedselsdato": "1974-10-31",
                 "statsborgerskap": [
                   {
                     "kode": "NOR",
@@ -200,7 +199,7 @@
               },
               "tilleggsId": [],
               "kjoenn": "MANN",
-              "foedselsdato": "1976-10-21T00:00:00",
+              "foedselsdato": "1976-10-21",
               "statsborgerskap": [
                 {
                   "kode": "NOR",
@@ -261,7 +260,7 @@
               "fornavn": "Morsom",
               "etternavn": "KIWI"
             },
-            "foedselsdato": "1963-04-14T00:00:00"
+            "foedselsdato": "1963-04-14"
           },
           "medsiktede": [
             {
@@ -276,7 +275,7 @@
                 },
                 "tilleggsId": [],
                 "kjoenn": "MANN",
-                "foedselsdato": "1970-07-19T00:00:00",
+                "foedselsdato": "1970-07-19",
                 "statsborgerskap": [
                   {
                     "kode": "NOR",
@@ -312,7 +311,7 @@
               },
               "tilleggsId": [],
               "kjoenn": "KVINNE",
-              "foedselsdato": "1970-01-01T00:00:00",
+              "foedselsdato": "1970-01-01",
               "statsborgerskap": [
                 {
                   "kode": "ARM",
@@ -366,7 +365,7 @@
               "fornavn": "Morsom",
               "etternavn": "KIWI"
             },
-            "foedselsdato": "1963-04-14T00:00:00"
+            "foedselsdato": "1963-04-14"
           },
           "medsiktede": [],
           "fornaermede": [
@@ -379,7 +378,7 @@
                 },
                 "tilleggsId": [],
                 "kjoenn": "MANN",
-                "foedselsdato": "1978-01-12T00:00:00",
+                "foedselsdato": "1978-01-12",
                 "statsborgerskap": [
                   {
                     "kode": "ITA",
@@ -435,7 +434,7 @@
               "fornavn": "Morsom",
               "etternavn": "KIWI"
             },
-            "foedselsdato": "1963-04-14T00:00:00"
+            "foedselsdato": "1963-04-14"
           },
           "medsiktede": [],
           "fornaermede": [
@@ -451,7 +450,7 @@
                 },
                 "tilleggsId": [],
                 "kjoenn": "KVINNE",
-                "foedselsdato": "1974-10-31T00:00:00",
+                "foedselsdato": "1974-10-31",
                 "statsborgerskap": [
                   {
                     "kode": "NOR",
@@ -492,7 +491,7 @@
       "internId": "1234567879",
       "overskrift": "Bestilling av varetektsplass, Kiwi",
       "kategori": { "kode": "BEGJAERING" },
-      "skrevetDato": "2022-11-03T00:00:00",
+      "skrevetDato": "2022-11-03",
       "forsendelse": {
         "mimeType": "application/pdf",
         "uri": "file:///asdfasdf",
@@ -505,7 +504,7 @@
       "kategori": {
         "kode": "Bestillingsvedlegg"
       },
-      "skrevetDato": "2022-10-14T00:00:00",
+      "skrevetDato": "2022-10-14",
       "forsendelse": {
         "mimeType": "application/pdf",
         "uri": "file:///asdfaasdfsdf",

--- a/kontrakter/politi/bestillvaretektsplass/pom.xml
+++ b/kontrakter/politi/bestillvaretektsplass/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>bestillvaretektsplass</artifactId>
+    <packaging>jar</packaging>
+    <name>Bestilling av varetektsplass</name>
+    <description>JSON-schema for bestilling av varetektsplass</description>
+
+    <parent>
+        <groupId>io.github.domstolene.esas</groupId>
+        <artifactId>kontrakter</artifactId>
+        <version>tmp</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <build>
+        <resources>
+            <resource>
+                <targetPath>schema</targetPath>
+                <directory>./</directory>
+                <includes>
+                    <include>**/*.json</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/kontrakter/politi/endreRestriksjoner/1.0/endreRestriksjoner.schema.json
+++ b/kontrakter/politi/endreRestriksjoner/1.0/endreRestriksjoner.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://politiet.no/politi/endreRestriksjoner/1.0/endreRestriksjoner",
+  "description": "Påtale gir ordre til Kriminalomsorgen om endringer i restriksjoner (lettelser), skjerpelser må komme fra domstolen. (IKKE KLAR)",
+
+  "type": "object",
+  "properties": {
+    "forsendelse": {
+      "$ref": "#/definitions/forsendelse",
+      "description": "avsender og mottaker"
+    },
+    "hovedStraffesaksnummer": {
+      "$ref": "#/definitions/straffesaksnummer",
+      "description": "BL Saksbehandlersak er hovedsaken i et sakskompleks (som er 1 eller flere straffesaker)"
+    }
+  },
+  "required": ["forsendelse", "hovedStraffesaksnummer"],
+  "additionalProperties": false,
+
+  "definitions": {
+    "forsendelse": {
+      "type": "object",
+      "properties": {
+        "meldingsId": {
+          "type": "string"
+        },
+        "sendtTid": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "avsender": {
+          "$ref": "#/definitions/avsender"
+        },
+        "mottakerOrganisasjon": {
+          "$ref": "#/definitions/organisasjon",
+          "description": "Domstol som skal være mottaker"
+        }
+      },
+      "required": [
+        "meldingsId",
+        "avsender",
+        "mottakerOrganisasjon",
+        "sendtTid"
+      ],
+      "additionalProperties": false
+    },
+
+    "avsender": {
+      "type": "object",
+      "properties": {
+        "organisasjon": {
+          "$ref": "#/definitions/organisasjon"
+        },
+        "person": {
+          "$ref": "#/definitions/ansattPerson",
+          "description": "Person som trykker på send til domstolen."
+        }
+      },
+      "required": ["organisasjon"],
+      "additionalProperties": false
+    },
+    "ansattPerson": {
+      "type": "object",
+      "description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
+      "properties": {
+        "tittel": {
+          "type": "string"
+        },
+        "fornavn": {
+          "type": "string"
+        },
+        "mellomnavn": {
+          "type": "string"
+        },
+        "etternavn": {
+          "type": "string"
+        },
+        "kontakt": {
+          "$ref": "#/definitions/kontaktInfo",
+          "description": "Er ikke med i første fase, burde inneholde kontaktinformasjon på forsendelsen."
+        }
+      },
+      "required": ["etternavn"],
+      "additionalProperties": false
+    },
+    "organisasjon": {
+      "type": "object",
+      "description": "Entydig identifikator av juridisk enhet. F.eks en spesifik domstol, embete eller politidistrikt",
+      "properties": {
+        "navn": {
+          "description": "F.eks. Oslo politidistikt, Riksadvokaten, Borgarting lagmannsrett",
+          "type": "string"
+        },
+        "organisasjonsnummer": {
+          "$ref": "#/definitions/organisasjonsnummer"
+        }
+      },
+      "required": ["organisasjonsnummer", "navn"],
+      "additionalProperties": false
+    },
+    "kontaktInfo": {
+      "type": "object",
+      "properties": {
+        "epost": {
+          "type": "string"
+        },
+        "telefonnummer": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/telefonnummer" }
+        }
+      },
+      "required": ["telefonnummer"],
+      "additionalProperties": false
+    },
+
+    "organisasjonsnummer": {
+      "type": "string",
+      "description": "Norsk organisasjonsnummer fra BRREG. Referanse til politistrikt, domstol, fengsel. https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/organisasjonsnummeret/",
+      "pattern": "^[0-9]+$",
+      "minLength": 9,
+      "maxLength": 9
+    },
+    "straffesaksnummer": {
+      "type": "string",
+      "description": "Som regel et løpenummer, men kan i fremtiden også inneholde bokstaver",
+      "minLength": 3,
+      "maxLength": 30
+    },
+    "telefonnummer": {
+      "type": "string",
+      "description": "Ett telefonnummer, norsk eller utenlands, med eller uten land prefix",
+      "maxLength": 30,
+      "minLength": 1
+    }
+  }
+}

--- a/kontrakter/politi/endreRestriksjoner/changelog.md
+++ b/kontrakter/politi/endreRestriksjoner/changelog.md
@@ -1,0 +1,1 @@
+# Endre restriksjoner endringslogg

--- a/kontrakter/politi/endreRestriksjoner/readme.md
+++ b/kontrakter/politi/endreRestriksjoner/readme.md
@@ -1,4 +1,5 @@
 # Endre restriksjoner (endreRestriksjoner)
+Denne meldingen sammen med [kjennelseVaretektPoliti](../kjennelseVaretektPoliti/readme.md) erstatter [oppdaterVaretekt](../oppdatervaretekt/readme.md)  
 Hvis påtale bestemmer seg for å lette på restriksjoner/isolasjon så skal denne meldingen brukes.
 
 **OBS** denne meldingen har prioritet 3 hos politiet og det betyr vi vet ikke vet når den vil bli implementert.

--- a/kontrakter/politi/endreRestriksjoner/readme.md
+++ b/kontrakter/politi/endreRestriksjoner/readme.md
@@ -1,0 +1,12 @@
+# Endre restriksjoner (endreRestriksjoner)
+Hvis påtale bestemmer seg for å lette på restriksjoner/isolasjon så skal denne meldingen brukes.
+
+**OBS** denne meldingen har prioritet 3 hos politiet og det betyr vi vet ikke vet når den vil bli implementert.
+
+## Headere forsendelse justisHub
+SchmaName=ENDRE_RESTRIKSJON_POLITI
+SchemaVersion=1.0  
+[RFC](../../../rfc/MessageName-header.md)
+
+[Se changelog for endringer](changelog.md)
+

--- a/kontrakter/politi/innsettelsesordre/readme.md
+++ b/kontrakter/politi/innsettelsesordre/readme.md
@@ -1,16 +1,15 @@
-# Innsettelsesordre
-Når siktet blir satt i fengsel hos Kriminalomsorgen (KDI) skal det alltid følge med en innsettelsesordre. Tidligere ble dette gjort ved at politiet fyllte ut en rødlapp som var et skjema med detaljer om siktede og soning i varetekt.
-Innsettelsesordren kan komme før kjennelse når en siktet blir flyttet fra politiarresten til Kriminalomsorgen og etter kjennelsen. Når innsettelsesordren kommer etter kjennelse så skal kjennelsen følge med.
-PIN er politiets innsettelsesordre som er den som kommer før kjennelse fra retten.
+# Innsettelsesordre (PIN)
+Innsettelsesordre er påtale sin ordre til Kriminalomsorgen om at en person skal sitte i varetekt og er istedet for en kjennelse fra retten når den ikke har kommet ennå. Denne blir kalt politiets innsettelsesordre av Kriminalomsorgen.
+
+*Hvis rettens kjennelse kommer så er det ikke nødvendig med en innsettelsesordre så tidligere versjon med "innsettelsesordre" også når det foreligger en kjennelse utgår. Meldingen er ikke oppdatert ennå. De endringene kommer i en egen MR*
 
 [Endringslogg](changelog.md)
-
-Dette er en stor og komplisert melding som vi må sjekke om passer sammen med arbeidsprosessene til poltiet. Tenker særlig på informasjon om helse og risiko. En bedre løsning er å dele opp med egen informasjon om helse og risiko og oppdatering når det endres.
-1. Innsettelseordre med fokus på juristen sin ordre, kun restriksjoner hvis kjennelse ikke er mottatt.
-2. Kjennelse fra domstolene kun egen melding, ikke en del av denne.
-3. Risiko og helse informasjon egen melding. Bør også gjelde bestilling av varetektsplass.
-
-## Begreper
+## Status - ikke godkjent
+Begge parter må være enige om innholdet før vi kan gå i produksjon.
+## Data
+I tillegg til forsendelse og detaljer om personen så blir følgende data med.
+### Straffesaksdata
+I første omgang så kommer informasjon kun fra hovedsaken og det kommer ikke med lovbud. Når siktelsen kommer (sammen med tilståelsessaker) så vil vi kunne sende med informasjon på alle straffesaker som siktede er involvert i.
 ### varetektsyklus
 En varetektsyklus er en serie av varetektshendelser fra en person blir pågrepet til han slipper ut av fengsel. F.eks. følgende hendelser.
  1. Besluting om pågripelse
@@ -19,17 +18,7 @@ En varetektsyklus er en serie av varetektshendelser fra en person blir pågrepet
  4. Overføre fra politiarresten til kriminalomsorgen.
  5. Slipper ut av fengsel ferdig med varetekt.
 
- VaretektSyklusId vil være lik på alle hendelser fra politiet på denne.
+ VaretektSyklusId vil være lik på alle hendelser fra politiet på denne, men ikke til å begynne med. Alle som meldinger som er på nytt format har egen syklusId.
 
 ## Avklaringer
-Restriksjonstype annet, trenger eksempler fra påtale.
-
-Deling av data, kan vi dele fødselsnummer mm. på vitner og verger. Hva trenger Kriminalomsorgen det til?
-Hva med kjønn, er det nødvendig på verger?
-
-Risiko og helseinformasjon ligger med som frivillig element nå, krever mer kartlegging av prosessen hos politiet. Kanskje denne kommer like i etterkant i egen melding eller kune i bestilling av varetektsplass.
-
-## Stegvis implementering
-Verger
-Straffesaker som er de som er med i siktelsen.
-Varetektsyklusid - senere 
+Er det behov for noen PDF dokumenter i den nye innsettelsesordren?

--- a/kontrakter/politi/kjennelseVaretektPoliti/1.0/eksempelfiler/kjennelseVaretektPoliti-eksempel-1.json
+++ b/kontrakter/politi/kjennelseVaretektPoliti/1.0/eksempelfiler/kjennelseVaretektPoliti-eksempel-1.json
@@ -111,10 +111,38 @@
       "organisasjonsnummer": "926722794",
       "navn": "Trøndelag tingrett"
     },
+    "domstolsaktoerer": {
+      "dommer": {
+        "etternavn": "Straff",
+        "fornavn": "Streng",
+        "tittel": "Dommerfullmektig"
+      }
+    },
     "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
     "avsagtDato": "2022-07-05",
     "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
-	"forlengelse": false,
+    "personVaretektDomstol": {
+      "internId": "23492414789",
+      "navn": {
+        "fornavn": "Morsom",
+        "etternavn": "KIWI"
+      },
+      "foedselsdato": "1963-04-14",
+      "kjoenn": "MANN",
+      "statsborgerskap": [
+        {
+          "kode": "NOR",
+          "navn": "Norge"
+        }
+      ],
+      "identitetsnummer": {
+        "foedselsnummer": "14846399381"
+      },
+      "tilleggsId": [],
+      "verger": []
+    },
+
+    "forlengelse": false,
     "restriksjoner": [
       {
         "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",

--- a/kontrakter/politi/kjennelseVaretektPoliti/1.0/eksempelfiler/kjennelseVaretektPoliti-eksempel-1.json
+++ b/kontrakter/politi/kjennelseVaretektPoliti/1.0/eksempelfiler/kjennelseVaretektPoliti-eksempel-1.json
@@ -1,0 +1,167 @@
+{
+  "forsendelse": {
+    "meldingsId": "607AC26F-E3C3-4241-AE76-8389B7715968",
+    "sendtTid": "2022-11-03T10:19:57+02:00",
+    "avsender": {
+      "organisasjon": {
+        "organisasjonsnummer": "983997953",
+        "navn": "Innlandet politidistrikt"
+      },
+      "person": {
+        "etternavn": "Politiets Datatjeneste"
+      }
+    },
+    "mottakerOrganisasjon": {
+      "organisasjonsnummer": "890286712",
+      "navn": "Bjørgvin fengsel"
+    }
+  },
+  "hovedStraffesaksnummer": "15434819",
+  "varetektSyklusId": "0AF242A3-EDCC-4FB7-B1DE-E974A360B73C",
+  "personVaretektInfo": {
+    "personVaretekt": {
+      "internId": "700892414",
+      "navn": {
+        "fornavn": "Morsom",
+        "etternavn": "KIWI"
+      },
+      "foedselsdato": "1963-04-14",
+      "kjoenn": "MANN",
+      "statsborgerskap": [
+        {
+          "kode": "NOR",
+          "navn": "Norge"
+        }
+      ],
+      "identitetsnummer": {
+        "foedselsnummer": "14846399381"
+      },
+      "tilleggsId": [],
+      "adresseGradering": "KLIENT_ADRESSE",
+      "personAdresse": {
+        "gradering": "KLIENT_ADRESSE",
+        "adresse": {
+          "adresselinjer": ["Bjørklund 21"],
+          "postnummer": "4137",
+          "poststed": "ÅRDAL I RYFYLKE"
+        }
+      },
+      "verger": []
+    },
+    "straffesaker": [
+      {
+        "straffesaksnummer": "15434819",
+        "detaljer": {
+          "hendelse": {
+            "gjerningstidspunktFra": "2022-01-01T00:00:00+02:00",
+            "gjerningstidspunktTil": "2022-01-01T00:00:00+02:00",
+            "gjerningssted": {
+              "adresselinjer": ["Waldemar Carlsens veg 4"],
+              "postnummer": "2214",
+              "poststed": "KONGSVINGER",
+              "land": {
+                "kode": "NOR",
+                "navn": "Norge"
+              }
+            }
+          },
+          "statistikkgruppe": {
+            "kode": "0933",
+            "navn": "Mindre tyveri diverse"
+          }
+        },
+        "involverte": {
+          "siktet": {
+            "internId": "700892414",
+            "navn": {
+              "fornavn": "Morsom",
+              "etternavn": "KIWI"
+            },
+            "foedselsdato": "1963-04-14"
+          },
+          "medsiktede": [
+            {
+              "person": {
+                "internId": "700893213",
+                "navn": {
+                  "fornavn": "Per",
+                  "etternavn": "OTTERSTAD"
+                },
+                "tilleggsId": [],
+                "kjoenn": "MANN",
+                "foedselsdato": "1975-12-12",
+                "statsborgerskap": [
+                  {
+                    "kode": "NOR",
+                    "navn": "Norge"
+                  }
+                ],
+                "verger": []
+              }
+            }
+          ],
+          "fornaermede": [],
+          "vitner": []
+        }
+      }
+    ]
+  },
+  "kjennelseVaretekt": {
+    "domstol": {
+      "organisasjonsnummer": "926722794",
+      "navn": "Trøndelag tingrett"
+    },
+    "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
+    "avsagtDato": "2022-07-05",
+    "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
+    "restriksjoner": [
+      {
+        "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
+        "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
+        "fraDato": "2022-07-06",
+        "tilDato": "2022-07-20"
+      },
+      {
+        "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
+        "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
+        "fraDato": "2022-07-21",
+        "tilDato": "2022-08-06"
+      }
+    ],
+    "isolasjonsKrav": [
+      {
+        "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
+        "isolasjonsType": "FULL",
+        "fraDato": "2022-07-06",
+        "tilDato": "2022-08-06"
+      }
+    ],
+    "fengsling": {
+      "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888",
+      "fraDato": "2022-07-06",
+      "tilDato": "2022-08-06",
+      "fengslingsFristDato": "2022-07-06",
+      "lovbud": {
+        "lovbudStreng": "strpl § 184, jf. § 185, jf. § 171 nr. 2"
+      },
+      "merknad": "Kiwi må i varetekt så fort som fy"
+    },
+    "anke": {
+      "anketDato": "2022-07-06",
+      "oppsettendeVirkning": false
+    }
+  },
+  "paagrepetTidspunkt": "2022-11-03T10:19:59+02:00",
+  "dokumenter": [
+    {
+      "internId": "1234567879",
+      "overskrift": "Begjæring om varetekt, Kiwi",
+      "skrevetDato": "2022-11-03",
+      "forsendelse": {
+        "mimeType": "application/pdf",
+        "uri": "file:///asdfasdf",
+        "sjekksum": "234s"
+      }
+    }
+  ]
+}

--- a/kontrakter/politi/kjennelseVaretektPoliti/1.0/eksempelfiler/kjennelseVaretektPoliti-eksempel-1.json
+++ b/kontrakter/politi/kjennelseVaretektPoliti/1.0/eksempelfiler/kjennelseVaretektPoliti-eksempel-1.json
@@ -114,6 +114,7 @@
     "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
     "avsagtDato": "2022-07-05",
     "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
+	"forlengelse": false,
     "restriksjoner": [
       {
         "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",

--- a/kontrakter/politi/kjennelseVaretektPoliti/1.0/kjennelseVaretektPoliti.schema.json
+++ b/kontrakter/politi/kjennelseVaretektPoliti/1.0/kjennelseVaretektPoliti.schema.json
@@ -583,12 +583,12 @@
       "additionalProperties": false
     },
     "person": {
-      "description": "Person med alle nyttige data som fødselsnummer adresse osv., SSP nummer kun på siktede, tiltalte.",
       "type": "object",
+      "description": "Person med alle nyttige data som fødselsnummer adresse osv., SSP nummer kun på siktede, tiltalte.",
       "properties": {
         "internId": {
-          "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId",
-          "type": "string"
+          "type": "string",
+          "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId"
         },
         "navn": {
           "$ref": "#/definitions/personnavn"
@@ -597,8 +597,8 @@
           "$ref": "#/definitions/date"
         },
         "kjoenn": {
-          "description": "Ukjent kjønn hvis denne ikke er med",
-          "$ref": "#/definitions/kjoenn"
+          "$ref": "#/definitions/kjoenn",
+          "description": "Ukjent kjønn hvis denne ikke er med"
         },
         "statsborgerskap": {
           "type": "array",
@@ -607,8 +607,8 @@
           }
         },
         "identitetsnummer": {
-          "description": "Fødselsnummer, D-nummer eller SSP nummer som er den i bruk",
-          "$ref": "#/definitions/personIdentifikator"
+          "$ref": "#/definitions/personIdentifikator",
+          "description": "Fødselsnummer, D-nummer eller SSP nummer som er i bruk. Siktede vil alltid ha med denne."
         },
         "tilleggsId": {
           "type": "array",
@@ -628,7 +628,7 @@
           "type": "array",
           "description": "Verge skal være med på siktet, fornærmet, vitne.",
           "items": {
-            "$ref": "#/definitions/personEnkel"
+            "$ref": "#/definitions/personRelatert"
           }
         }
       },
@@ -653,7 +653,39 @@
         "navn": {
           "$ref": "#/definitions/personnavn"
         },
-        "foedselsdato": { "$ref": "#/definitions/date" }
+        "foedselsdato": {
+          "$ref": "#/definitions/date"
+        }
+      },
+      "required": ["internId", "navn"],
+      "additionalProperties": false
+    },
+    "personRelatert": {
+      "type": "object",
+      "description": "Personer relatert til straffesaken som verger og advokater",
+      "properties": {
+        "internId": {
+          "type": "string",
+          "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId, en verge kan f.eks. også være vitne i saken"
+        },
+        "tittel": {
+          "type": "string"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": {
+          "$ref": "#/definitions/date",
+          "description": "På de vi har det, sjekke om vi kan dele"
+        },
+        "kjoenn": {
+          "$ref": "#/definitions/kjoenn",
+          "description": "Ukjent kjønn hvis denne ikke er med"
+        },
+        "foedselsnummer": {
+          "$ref": "#/definitions/foedselsnummer",
+          "description": "Fødselsnummer f.eks på verger, men usikker på om det er behov. Vil ikke være utfylt på advokater."
+        }
       },
       "required": ["internId", "navn"],
       "additionalProperties": false

--- a/kontrakter/politi/kjennelseVaretektPoliti/1.0/kjennelseVaretektPoliti.schema.json
+++ b/kontrakter/politi/kjennelseVaretektPoliti/1.0/kjennelseVaretektPoliti.schema.json
@@ -55,15 +55,9 @@
           "minContains": 1,
           "maxContains": 4
         },
-        "postnummer": {
-          "type": "string"
-        },
-        "poststed": {
-          "type": "string"
-        },
-        "land": {
-          "$ref": "#/definitions/landType"
-        }
+        "postnummer": { "type": "string" },
+        "poststed": { "type": "string" },
+        "land": { "$ref": "#/definitions/landType" }
       },
       "required": ["adresselinjer"],
       "additionalProperties": false
@@ -78,7 +72,8 @@
       "description": "Data om personen og straffesaker personen er involvert i",
       "properties": {
         "personVaretekt": {
-          "$ref": "#/definitions/person"
+          "$ref": "#/definitions/person",
+          "description": "Straffesak personen, forskjeller ser du ved å sammenligne med data fra domstolen"
         },
         "straffesaker": {
           "type": "array",
@@ -94,9 +89,7 @@
     "anke": {
       "description": "Anke av fengsling/restriksjon/kjennelse",
       "properties": {
-        "anketDato": {
-          "$ref": "#/definitions/date"
-        },
+        "anketDato": { "$ref": "#/definitions/date" },
         "oppsettendeVirkning": {
           "type": "boolean"
         }
@@ -109,18 +102,10 @@
       "type": "object",
       "description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
       "properties": {
-        "tittel": {
-          "type": "string"
-        },
-        "fornavn": {
-          "type": "string"
-        },
-        "mellomnavn": {
-          "type": "string"
-        },
-        "etternavn": {
-          "type": "string"
-        },
+        "tittel": { "type": "string" },
+        "fornavn": { "type": "string" },
+        "mellomnavn": { "type": "string" },
+        "etternavn": { "type": "string" },
         "kontakt": {
           "$ref": "#/definitions/kontaktInfo",
           "description": "Er ikke med i første fase, burde inneholde kontaktinformasjon på forsendelsen."
@@ -147,21 +132,11 @@
       "type": "object",
       "description": "Dokument som oversendes på justishub",
       "properties": {
-        "internId": {
-          "type": "string"
-        },
-        "kategori": {
-          "$ref": "#/definitions/kodeverk"
-        },
-        "overskrift": {
-          "type": "string"
-        },
-        "skrevetDato": {
-          "$ref": "#/definitions/date"
-        },
-        "forsendelse": {
-          "$ref": "#/definitions/dokumentForsendelse"
-        }
+        "internId": { "type": "string" },
+        "kategori": { "$ref": "#/definitions/kodeverk" },
+        "overskrift": { "type": "string" },
+        "skrevetDato": { "$ref": "#/definitions/date" },
+        "forsendelse": { "$ref": "#/definitions/dokumentForsendelse" }
       },
       "required": ["overskrift", "forsendelse"],
       "additionalProperties": false
@@ -170,15 +145,9 @@
       "type": "object",
       "description": "Detaljer om lokasjon og type",
       "properties": {
-        "mimeType": {
-          "type": "string"
-        },
-        "uri": {
-          "type": "string"
-        },
-        "sjekksum": {
-          "type": "string"
-        }
+        "mimeType": { "type": "string" },
+        "uri": { "type": "string" },
+        "sjekksum": { "type": "string" }
       },
       "required": ["mimeType", "uri", "sjekksum"],
       "additionalProperties": false
@@ -186,16 +155,12 @@
     "forsendelse": {
       "type": "object",
       "properties": {
-        "meldingsId": {
-          "type": "string"
-        },
+        "meldingsId": { "type": "string" },
         "sendtTid": {
           "type": "string",
           "format": "date-time"
         },
-        "avsender": {
-          "$ref": "#/definitions/avsender"
-        },
+        "avsender": { "$ref": "#/definitions/avsender" },
         "mottakerOrganisasjon": {
           "$ref": "#/definitions/organisasjon",
           "description": "Kriminalomsorg som skal være mottaker"
@@ -209,25 +174,17 @@
       ],
       "additionalProperties": false
     },
-    "fengslingKjennelse": {
-      "description": "Fengsling som en del av kjennelsen, uten datoer så er det ikke noe fengsel",
+    "fengsling": {
+      "description": "Fengsling som en del av kjennelsen, uten datoer så er det ikke noe fengsel nå.",
       "properties": {
         "fengslingsId": {
           "type": "string",
           "description": "fengslingsid som opprettes i DA (GUID)"
         },
-        "fraDato": {
-          "$ref": "#/definitions/date"
-        },
-        "tilDato": {
-          "$ref": "#/definitions/date"
-        },
-        "fengslingsFristDato": {
-          "$ref": "#/definitions/date"
-        },
-        "lovbud": {
-          "$ref": "#/definitions/lovbudEnkel"
-        },
+        "fraDato": { "$ref": "#/definitions/date" },
+        "tilDato": { "$ref": "#/definitions/date" },
+        "fengslingsFristDato": { "$ref": "#/definitions/date" },
+        "lovbud": { "$ref": "#/definitions/lovbudEnkel" },
         "merknad": {
           "type": "string",
           "description": "Merknad til fengslingen"
@@ -241,18 +198,10 @@
       "description": "Foretak/ organisasjon som er med i en straffesak som f.eks. fornærmet",
       "type": "object",
       "properties": {
-        "internId": {
-          "type": "string"
-        },
-        "organisasjonsnummer": {
-          "$ref": "#/definitions/organisasjonsnummer"
-        },
-        "navn": {
-          "type": "string"
-        },
-        "adresse": {
-          "$ref": "#/definitions/adresse"
-        }
+        "internId": { "type": "string" },
+        "organisasjonsnummer": { "$ref": "#/definitions/organisasjonsnummer" },
+        "navn": { "type": "string" },
+        "adresse": { "$ref": "#/definitions/adresse" }
       },
       "required": ["internId", "navn"],
       "additionalProperties": false
@@ -313,26 +262,18 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "siktet": {
-          "$ref": "#/definitions/personEnkel"
-        },
+        "siktet": { "$ref": "#/definitions/personEnkel" },
         "medsiktede": {
           "type": "array",
-          "items": {
-            "$ref": "#/definitions/personForetak"
-          }
+          "items": { "$ref": "#/definitions/personForetak" }
         },
         "fornaermede": {
           "type": "array",
-          "items": {
-            "$ref": "#/definitions/personForetak"
-          }
+          "items": { "$ref": "#/definitions/personForetak" }
         },
         "vitner": {
           "type": "array",
-          "items": {
-            "$ref": "#/definitions/person"
-          }
+          "items": { "$ref": "#/definitions/person" }
         }
       },
       "required": ["medsiktede", "fornaermede", "vitner"]
@@ -340,12 +281,8 @@
     "kodeverk": {
       "type": "object",
       "properties": {
-        "kode": {
-          "type": "string"
-        },
-        "navn": {
-          "type": "string"
-        }
+        "kode": { "type": "string" },
+        "navn": { "type": "string" }
       },
       "required": ["kode"],
       "additionalProperties": false
@@ -353,9 +290,7 @@
     "kontaktInfo": {
       "type": "object",
       "properties": {
-        "epost": {
-          "type": "string"
-        },
+        "epost": { "type": "string" },
         "telefonnummer": {
           "type": "array",
           "items": { "$ref": "#/definitions/telefonnummer" }
@@ -369,33 +304,35 @@
       "type": "object",
       "properties": {
         "domstol": { "$ref": "#/definitions/organisasjon" },
+        "domstolsaktoerer": { "$ref": "#/definitions/domstolsaktoerer" },
         "avgjoerelseId": {
           "type": "string",
           "description": "Domstolen sin nøkkel til avgjørelsen. Kan bli brukt i forbindelse med anke/forlengelse"
         },
-        "avsagtDato": {
-          "$ref": "#/definitions/date"
-        },
+        "avsagtDato": { "$ref": "#/definitions/date" },
         "kravid": {
           "type": "string",
           "description": "Kravid som opprettes i politiet (begjæring om varetektsfengsling)"
         },
-		"forlengelse": {"type": "boolean"},
+        "personVaretektDomstol": {
+          "$ref": "#/definitions/person",
+          "description": "Persondata fra domstolene, kan være forskjellig fra politiet sine data"
+        },
+        "forlengelse": {
+          "type": "boolean",
+          "description": "Forlengelse = true også hvis det er en endring i restriksjoner fra domstolene"
+        },
+        "fengsling": {
+          "$ref": "#/definitions/fengsling",
+          "description": "Førstegangsfengslinger vil alltid inneholde fengsling, men senere kan det komme med kun restriksjoner, isolasjon."
+        },
         "restriksjoner": {
           "type": "array",
-          "items": {
-            "$ref": "#/definitions/restriksjon"
-          }
+          "items": { "$ref": "#/definitions/restriksjon" }
         },
         "isolasjonsKrav": {
           "type": "array",
-          "items": {
-            "$ref": "#/definitions/isolasjon"
-          }
-        },
-        "fengsling": {
-          "$ref": "#/definitions/fengslingKjennelse",
-          "description": "Førstegangsfengslinger vil alltid inneholde fengslingskjennelse, men senere kan det komme med kun restriksjoner, isolasjon"
+          "items": { "$ref": "#/definitions/isolasjon" }
         },
         "anke": {
           "$ref": "#/definitions/anke",
@@ -404,11 +341,12 @@
       },
       "required": [
         "domstol",
+        "domstolsaktoerer",
         "avgjoerelseId",
         "avsagtDato",
+        "personVaretektDomstol",
         "kravid",
-		"forlengelse",
-        "fengsling",
+        "forlengelse",
         "restriksjoner",
         "isolasjonsKrav"
       ],
@@ -423,40 +361,28 @@
       "description": "Fødselsnummer, D-nummer eller SSP nummer.",
       "type": "object",
       "properties": {
-        "foedselsnummer": {
-          "$ref": "#/definitions/foedselsnummer"
-        },
-        "sspNummer": {
-          "$ref": "#/definitions/sspNummer"
-        },
-        "dNummer": {
-          "$ref": "#/definitions/dNummer"
-        }
+        "foedselsnummer": { "$ref": "#/definitions/foedselsnummer" },
+        "sspNummer": { "$ref": "#/definitions/sspNummer" },
+        "dNummer": { "$ref": "#/definitions/dNummer" }
       },
       "oneOf": [
         {
           "properties": {
-            "foedselsnummer": {
-              "$ref": "#/definitions/foedselsnummer"
-            }
+            "foedselsnummer": { "$ref": "#/definitions/foedselsnummer" }
           },
           "required": ["foedselsnummer"],
           "additionalProperties": false
         },
         {
           "properties": {
-            "sspNummer": {
-              "$ref": "#/definitions/sspNummer"
-            }
+            "sspNummer": { "$ref": "#/definitions/sspNummer" }
           },
           "required": ["sspNummer"],
           "additionalProperties": false
         },
         {
           "properties": {
-            "dNummer": {
-              "$ref": "#/definitions/dNummer"
-            }
+            "dNummer": { "$ref": "#/definitions/dNummer" }
           },
           "required": ["dNummer"],
           "additionalProperties": false
@@ -473,9 +399,7 @@
           "minLength": 3,
           "maxLength": 3
         },
-        "navn": {
-          "type": "string"
-        }
+        "navn": { "type": "string" }
       },
       "required": ["kode"]
     },
@@ -483,12 +407,8 @@
       "type": "object",
       "description": "Enkel lovbudreferanse kun lovbudstreng",
       "properties": {
-        "lovbudId": {
-          "type": "string"
-        },
-        "lovbudStreng": {
-          "type": "string"
-        }
+        "lovbudId": { "type": "string" },
+        "lovbudStreng": { "type": "string" }
       },
       "required": ["lovbudStreng"],
       "additionalProperties": false
@@ -501,39 +421,17 @@
           "description": "F.eks. Oslo politidistikt, Riksadvokaten, Borgarting lagmannsrett",
           "type": "string"
         },
-        "organisasjonsnummer": {
-          "$ref": "#/definitions/organisasjonsnummer"
-        }
+        "organisasjonsnummer": { "$ref": "#/definitions/organisasjonsnummer" }
       },
       "required": ["organisasjonsnummer", "navn"],
       "additionalProperties": false
     },
-    "periodeStartAntall": {
-      "description": "Periode for fensling eller restriksjon, bruker ikke å spesifisere startdato, derfor lengde og antall dager inn i fengslingen for restriksjoner",
-      "type": "object",
-      "required": ["startDag", "antallDager"],
-      "additionalProperties": false,
-      "properties": {
-        "startDag": {
-          "type": "integer"
-        },
-        "antallDager": {
-          "type": "integer"
-        }
-      }
-    },
     "personnavn": {
       "type": "object",
       "properties": {
-        "fornavn": {
-          "type": "string"
-        },
-        "mellomnavn": {
-          "type": "string"
-        },
-        "etternavn": {
-          "type": "string"
-        }
+        "fornavn": { "type": "string" },
+        "mellomnavn": { "type": "string" },
+        "etternavn": { "type": "string" }
       },
       "required": ["etternavn"],
       "additionalProperties": false
@@ -542,28 +440,20 @@
       "description": "En siktet eller fornærmet kan være en person eller et foretak, denne typen er enten person eller foretak.",
       "type": "object",
       "properties": {
-        "person": {
-          "$ref": "#/definitions/person"
-        },
-        "foretak": {
-          "$ref": "#/definitions/foretak"
-        }
+        "person": { "$ref": "#/definitions/person" },
+        "foretak": { "$ref": "#/definitions/foretak" }
       },
       "oneOf": [
         {
           "properties": {
-            "person": {
-              "$ref": "#/definitions/person"
-            }
+            "person": { "$ref": "#/definitions/person" }
           },
           "additionalProperties": false,
           "required": ["person"]
         },
         {
           "properties": {
-            "foretak": {
-              "$ref": "#/definitions/foretak"
-            }
+            "foretak": { "$ref": "#/definitions/foretak" }
           },
           "additionalProperties": false,
           "required": ["foretak"]
@@ -574,12 +464,8 @@
       "description": "Kan være graderte adresser",
       "type": "object",
       "properties": {
-        "gradering": {
-          "$ref": "#/definitions/adresseGradering"
-        },
-        "adresse": {
-          "$ref": "#/definitions/adresse"
-        }
+        "gradering": { "$ref": "#/definitions/adresseGradering" },
+        "adresse": { "$ref": "#/definitions/adresse" }
       },
       "required": ["adresse"],
       "additionalProperties": false
@@ -592,21 +478,15 @@
           "type": "string",
           "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId"
         },
-        "navn": {
-          "$ref": "#/definitions/personnavn"
-        },
-        "foedselsdato": {
-          "$ref": "#/definitions/date"
-        },
+        "navn": { "$ref": "#/definitions/personnavn" },
+        "foedselsdato": { "$ref": "#/definitions/date" },
         "kjoenn": {
           "$ref": "#/definitions/kjoenn",
           "description": "Ukjent kjønn hvis denne ikke er med"
         },
         "statsborgerskap": {
           "type": "array",
-          "items": {
-            "$ref": "#/definitions/land"
-          }
+          "items": { "$ref": "#/definitions/land" }
         },
         "identitetsnummer": {
           "$ref": "#/definitions/personIdentifikator",
@@ -614,9 +494,7 @@
         },
         "tilleggsId": {
           "type": "array",
-          "items": {
-            "$ref": "#/definitions/personIdentifikator"
-          },
+          "items": { "$ref": "#/definitions/personIdentifikator" },
           "description": "Kan være SSP nummer hvis person har D-nummer, fremtidig historiske nummer?"
         },
         "adresseGradering": {
@@ -629,9 +507,7 @@
         "verger": {
           "type": "array",
           "description": "Verge skal være med på siktet, fornærmet, vitne.",
-          "items": {
-            "$ref": "#/definitions/personRelatert"
-          }
+          "items": { "$ref": "#/definitions/personRelatert" }
         }
       },
       "required": [
@@ -652,12 +528,8 @@
           "type": "string",
           "description": "Intern som peker på samme person i en spesifikk melding"
         },
-        "navn": {
-          "$ref": "#/definitions/personnavn"
-        },
-        "foedselsdato": {
-          "$ref": "#/definitions/date"
-        }
+        "navn": { "$ref": "#/definitions/personnavn" },
+        "foedselsdato": { "$ref": "#/definitions/date" }
       },
       "required": ["internId", "navn"],
       "additionalProperties": false
@@ -670,12 +542,8 @@
           "type": "string",
           "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId, en verge kan f.eks. også være vitne i saken"
         },
-        "tittel": {
-          "type": "string"
-        },
-        "navn": {
-          "$ref": "#/definitions/personnavn"
-        },
+        "tittel": { "type": "string" },
+        "navn": { "$ref": "#/definitions/personnavn" },
         "foedselsdato": {
           "$ref": "#/definitions/date",
           "description": "På de vi har det, sjekke om vi kan dele"
@@ -700,9 +568,7 @@
           "type": "string",
           "description": "restriksjonsId som opprettes i DA (GUID)"
         },
-        "restriksjonsType": {
-          "$ref": "#/definitions/restriksjonsType"
-        },
+        "restriksjonsType": { "$ref": "#/definitions/restriksjonsType" },
         "fraDato": {
           "description": "Om begjæringen ikke tas til følge er dette feltet satt til null.",
           "$ref": "#/definitions/date"
@@ -717,12 +583,12 @@
     },
     "restriksjonsType": {
       "description": "Liste over de ulike restriksjonene",
+      "type": "string",
       "enum": [
         "BREV_OG_BESOEKSFORBUD",
         "BREV_OG_BESOEKSKONTROLL",
         "MEDIEFORBUD"
-      ],
-      "type": "string"
+      ]
     },
     "straffesakInvolverte": {
       "description": "Straffesak med statistikkgrupper, krimtype og de involverte",
@@ -730,27 +596,34 @@
       "required": ["straffesaksnummer", "detaljer", "involverte"],
       "additionalProperties": true,
       "properties": {
-        "straffesaksnummer": {
-          "$ref": "#/definitions/straffesaksnummer"
-        },
+        "straffesaksnummer": { "$ref": "#/definitions/straffesaksnummer" },
         "detaljer": { "$ref": "#/definitions/straffesakDetaljer" },
         "involverte": { "$ref": "#/definitions/involverteStraffesak" }
       }
     },
-
+    "domstolsaktoerer": {
+      "type": "object",
+      "description": "Aktører fra domstolen",
+      "properties": {
+        "dommer": {
+          "$ref": "#/definitions/ansattPerson",
+          "description": "Dommer på saken"
+        },
+        "saksbehandler": {
+          "$ref": "#/definitions/ansattPerson",
+          "description": "Saksbehandler på saken"
+        }
+      },
+      "required": ["dommer"],
+      "additionalProperties": false
+    },
     "straffesakDetaljer": {
       "type": "object",
       "description": "Detaljer rundt straffesaken, OBS krimType er ikke klart ennå-.s",
       "properties": {
-        "hendelse": {
-          "$ref": "#/definitions/hendelse"
-        },
-        "statistikkgruppe": {
-          "$ref": "#/definitions/kodeverk"
-        },
-        "krimtype": {
-          "$ref": "#/definitions/kodeverk"
-        }
+        "hendelse": { "$ref": "#/definitions/hendelse" },
+        "statistikkgruppe": { "$ref": "#/definitions/kodeverk" },
+        "krimtype": { "$ref": "#/definitions/kodeverk" }
       },
       "required": ["hendelse", "statistikkgruppe"],
       "additionalProperties": false
@@ -765,9 +638,7 @@
           "minLength": 3,
           "maxLength": 3
         },
-        "navn": {
-          "type": "string"
-        }
+        "navn": { "type": "string" }
       },
       "required": ["kode"],
       "additionalProperties": false

--- a/kontrakter/politi/kjennelseVaretektPoliti/1.0/kjennelseVaretektPoliti.schema.json
+++ b/kontrakter/politi/kjennelseVaretektPoliti/1.0/kjennelseVaretektPoliti.schema.json
@@ -1,0 +1,786 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://politiet.no/politi/kjennelseVaretektPoliti/1.0/kjennelseVaretektPoliti",
+  "description": "Kjennelse fra domstolen førtegangsfengsling eller forlengelser.",
+  "type": "object",
+  "properties": {
+    "forsendelse": {
+      "$ref": "#/definitions/forsendelse",
+      "description": "avsender og mottaker"
+    },
+    "hovedStraffesaksnummer": {
+      "$ref": "#/definitions/straffesaksnummer",
+      "description": "BL Saksbehandlersak er hovedsaken i et sakskompleks (som er 1 eller flere straffesaker)"
+    },
+    "varetektSyklusId": {
+      "type": "string",
+      "description": "En syklus fra pågripelse til løslatelse, vil ikke være med til å begynne med"
+    },
+    "personVaretektInfo": {
+      "$ref": "#/definitions/personVaretektInfo"
+    },
+    "kjennelseVaretekt": {
+      "$ref": "#/definitions/kjennelseVaretekt"
+    },
+    "paagrepetTidspunkt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "dokumenter": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/dokument"
+      }
+    }
+  },
+  "required": [
+    "forsendelse",
+    "hovedStraffesaksnummer",
+    "personVaretektInfo",
+    "kjennelseVaretekt",
+    "dokumenter"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "adresse": {
+      "type": "object",
+      "properties": {
+        "adresselinjer": {
+          "type": "array",
+          "contains": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "minContains": 1,
+          "maxContains": 4
+        },
+        "postnummer": {
+          "type": "string"
+        },
+        "poststed": {
+          "type": "string"
+        },
+        "land": {
+          "$ref": "#/definitions/landType"
+        }
+      },
+      "required": ["adresselinjer"],
+      "additionalProperties": false
+    },
+    "adresseGradering": {
+      "description": "Samme enum som folkeregisteret, ugradert hvis den ikke er gradert",
+      "type": "string",
+      "enum": ["KLIENT_ADRESSE", "FORTROLIG", "STRENGT_FORTROLIG"]
+    },
+    "personVaretektInfo": {
+      "type": "object",
+      "description": "Data om personen og straffesaker personen er involvert i",
+      "properties": {
+        "personVaretekt": {
+          "$ref": "#/definitions/person"
+        },
+        "straffesaker": {
+          "type": "array",
+          "title": "straffesaker",
+          "items": { "$ref": "#/definitions/straffesakInvolverte" },
+          "minItems": 1
+        }
+      },
+      "required": ["personVaretekt", "straffesaker"],
+      "additionalProperties": false
+    },
+
+    "anke": {
+      "description": "Anke av fengsling/restriksjon/kjennelse",
+      "properties": {
+        "anketDato": {
+          "$ref": "#/definitions/date"
+        },
+        "oppsettendeVirkning": {
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "required": ["anketDato"],
+      "additionalProperties": false
+    },
+    "ansattPerson": {
+      "type": "object",
+      "description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
+      "properties": {
+        "tittel": {
+          "type": "string"
+        },
+        "fornavn": {
+          "type": "string"
+        },
+        "mellomnavn": {
+          "type": "string"
+        },
+        "etternavn": {
+          "type": "string"
+        },
+        "kontakt": {
+          "$ref": "#/definitions/kontaktInfo",
+          "description": "Er ikke med i første fase, burde inneholde kontaktinformasjon på forsendelsen."
+        }
+      },
+      "required": ["etternavn"],
+      "additionalProperties": false
+    },
+    "avsender": {
+      "type": "object",
+      "properties": {
+        "organisasjon": {
+          "$ref": "#/definitions/organisasjon"
+        },
+        "person": {
+          "$ref": "#/definitions/ansattPerson",
+          "description": "Person som trykker på send til domstolen."
+        }
+      },
+      "required": ["organisasjon"],
+      "additionalProperties": false
+    },
+    "dokument": {
+      "type": "object",
+      "description": "Dokument som oversendes på justishub",
+      "properties": {
+        "internId": {
+          "type": "string"
+        },
+        "kategori": {
+          "$ref": "#/definitions/kodeverk"
+        },
+        "overskrift": {
+          "type": "string"
+        },
+        "skrevetDato": {
+          "$ref": "#/definitions/date"
+        },
+        "forsendelse": {
+          "$ref": "#/definitions/dokumentForsendelse"
+        }
+      },
+      "required": ["overskrift", "forsendelse"],
+      "additionalProperties": false
+    },
+    "dokumentForsendelse": {
+      "type": "object",
+      "description": "Detaljer om lokasjon og type",
+      "properties": {
+        "mimeType": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "sjekksum": {
+          "type": "string"
+        }
+      },
+      "required": ["mimeType", "uri", "sjekksum"],
+      "additionalProperties": false
+    },
+    "forsendelse": {
+      "type": "object",
+      "properties": {
+        "meldingsId": {
+          "type": "string"
+        },
+        "sendtTid": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "avsender": {
+          "$ref": "#/definitions/avsender"
+        },
+        "mottakerOrganisasjon": {
+          "$ref": "#/definitions/organisasjon",
+          "description": "Kriminalomsorg som skal være mottaker"
+        }
+      },
+      "required": [
+        "meldingsId",
+        "avsender",
+        "mottakerOrganisasjon",
+        "sendtTid"
+      ],
+      "additionalProperties": false
+    },
+    "fengslingKjennelse": {
+      "description": "Fengsling som en del av kjennelsen, uten datoer så er det ikke noe fengsel",
+      "properties": {
+        "fengslingsId": {
+          "type": "string",
+          "description": "fengslingsid som opprettes i DA (GUID)"
+        },
+        "fraDato": {
+          "$ref": "#/definitions/date"
+        },
+        "tilDato": {
+          "$ref": "#/definitions/date"
+        },
+        "fengslingsFristDato": {
+          "$ref": "#/definitions/date"
+        },
+        "lovbud": {
+          "$ref": "#/definitions/lovbudEnkel"
+        },
+        "merknad": {
+          "type": "string",
+          "description": "Merknad til fengslingen"
+        }
+      },
+      "required": ["fengslingsId"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "foretak": {
+      "description": "Foretak/ organisasjon som er med i en straffesak som f.eks. fornærmet",
+      "type": "object",
+      "properties": {
+        "internId": {
+          "type": "string"
+        },
+        "organisasjonsnummer": {
+          "$ref": "#/definitions/organisasjonsnummer"
+        },
+        "navn": {
+          "type": "string"
+        },
+        "adresse": {
+          "$ref": "#/definitions/adresse"
+        }
+      },
+      "required": ["internId", "navn"],
+      "additionalProperties": false
+    },
+    "hendelse": {
+      "title": "hendelse",
+      "type": "object",
+      "required": [
+        "gjerningstidspunktFra",
+        "gjerningstidspunktTil",
+        "gjerningssted"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "gjerningstidspunktFra": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "gjerningstidspunktTil": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "gjerningssted": {
+          "$ref": "#/definitions/adresse"
+        }
+      }
+    },
+    "isolasjon": {
+      "description": "Isolasjon fra domstolen, når vi har mottatt den, uten til fra dato kun når det er anke",
+      "properties": {
+        "isolasjonsId": {
+          "type": "string",
+          "description": "isolasjonsId som opprettes i DA (GUID)"
+        },
+        "isolasjonsType": {
+          "$ref": "#/definitions/isolasjonsType"
+        },
+        "fraDato": {
+          "$ref": "#/definitions/date",
+          "description": "Om begjæringen ikke tas til følge skal dette feltet settes til null."
+        },
+        "tilDato": {
+          "$ref": "#/definitions/date",
+          "description": "Om begjæringen ikke tas til følge skal dette feltet settes til null."
+        }
+      },
+      "required": ["isolasjonsId", "isolasjonsType"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "isolasjonsType": {
+      "description": "Liste over de ulike isolasjonstyper",
+      "enum": ["FULL", "DELVIS"],
+      "type": "string"
+    },
+    "involverteStraffesak": {
+      "description": "siktede, vitner og fornærmede",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "siktet": {
+          "$ref": "#/definitions/personEnkel"
+        },
+        "medsiktede": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personForetak"
+          }
+        },
+        "fornaermede": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personForetak"
+          }
+        },
+        "vitner": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/person"
+          }
+        }
+      },
+      "required": ["medsiktede", "fornaermede", "vitner"]
+    },
+    "kodeverk": {
+      "type": "object",
+      "properties": {
+        "kode": {
+          "type": "string"
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["kode"],
+      "additionalProperties": false
+    },
+    "kontaktInfo": {
+      "type": "object",
+      "properties": {
+        "epost": {
+          "type": "string"
+        },
+        "telefonnummer": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/telefonnummer" }
+        }
+      },
+      "required": ["telefonnummer"],
+      "additionalProperties": false
+    },
+    "kjennelseVaretekt": {
+      "description": "Kjennelse på varetektsfengsling fra domstolen som sendes videre til Kriminalomsorgen",
+      "type": "object",
+      "properties": {
+        "domstol": { "$ref": "#/definitions/organisasjon" },
+        "avgjoerelseId": {
+          "type": "string",
+          "description": "Domstolen sin nøkkel til avgjørelsen. Kan bli brukt i forbindelse med anke/forlengelse"
+        },
+        "avsagtDato": {
+          "$ref": "#/definitions/date"
+        },
+        "kravid": {
+          "type": "string",
+          "description": "Kravid som opprettes i politiet"
+        },
+        "restriksjoner": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/restriksjon"
+          }
+        },
+        "isolasjonsKrav": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/isolasjon"
+          }
+        },
+        "fengsling": {
+          "$ref": "#/definitions/fengslingKjennelse",
+          "description": "Førstegangsfengslinger vil alltid inneholde fengslingskjennelse, men senere kan det komme med kun restriksjoner, isolasjon"
+        },
+        "anke": {
+          "$ref": "#/definitions/anke",
+          "description": "Settes kun dersom hele eller deler av avgjørelsen ankes før kjennelsen sendes til påtale"
+        }
+      },
+      "required": [
+        "domstol",
+        "avgjoerelseId",
+        "avsagtDato",
+        "kravid",
+        "fengsling",
+        "restriksjoner",
+        "isolasjonsKrav"
+      ],
+      "additionalProperties": false
+    },
+    "kjoenn": {
+      "description": "Samme enum som folkeregisteret",
+      "type": "string",
+      "enum": ["KVINNE", "MANN"]
+    },
+    "personIdentifikator": {
+      "description": "Fødselsnummer, D-nummer eller SSP nummer.",
+      "type": "object",
+      "properties": {
+        "foedselsnummer": {
+          "$ref": "#/definitions/foedselsnummer"
+        },
+        "sspNummer": {
+          "$ref": "#/definitions/sspNummer"
+        },
+        "dNummer": {
+          "$ref": "#/definitions/dNummer"
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "foedselsnummer": {
+              "$ref": "#/definitions/foedselsnummer"
+            }
+          },
+          "required": ["foedselsnummer"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "sspNummer": {
+              "$ref": "#/definitions/sspNummer"
+            }
+          },
+          "required": ["sspNummer"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "dNummer": {
+              "$ref": "#/definitions/dNummer"
+            }
+          },
+          "required": ["dNummer"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "landType": {
+      "description": "En landkode bestaar av tre store bokstaver fra kodelisten ISO 3166-1-alpha-3. Hentes fra kodeverk nationality.xml",
+      "type": "object",
+      "properties": {
+        "kode": {
+          "type": "string",
+          "pattern": "[A-Z]+",
+          "minLength": 3,
+          "maxLength": 3
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["kode"]
+    },
+    "lovbudEnkel": {
+      "type": "object",
+      "description": "Enkel lovbudreferanse kun lovbudstreng",
+      "properties": {
+        "lovbudId": {
+          "type": "string"
+        },
+        "lovbudStreng": {
+          "type": "string"
+        }
+      },
+      "required": ["lovbudStreng"],
+      "additionalProperties": false
+    },
+    "organisasjon": {
+      "type": "object",
+      "description": "Entydig identifikator av juridisk enhet. F.eks en spesifik domstol eller kriminalomsorg",
+      "properties": {
+        "navn": {
+          "description": "F.eks. Oslo politidistikt, Riksadvokaten, Borgarting lagmannsrett",
+          "type": "string"
+        },
+        "organisasjonsnummer": {
+          "$ref": "#/definitions/organisasjonsnummer"
+        }
+      },
+      "required": ["organisasjonsnummer", "navn"],
+      "additionalProperties": false
+    },
+    "periodeStartAntall": {
+      "description": "Periode for fensling eller restriksjon, bruker ikke å spesifisere startdato, derfor lengde og antall dager inn i fengslingen for restriksjoner",
+      "type": "object",
+      "required": ["startDag", "antallDager"],
+      "additionalProperties": false,
+      "properties": {
+        "startDag": {
+          "type": "integer"
+        },
+        "antallDager": {
+          "type": "integer"
+        }
+      }
+    },
+    "personnavn": {
+      "type": "object",
+      "properties": {
+        "fornavn": {
+          "type": "string"
+        },
+        "mellomnavn": {
+          "type": "string"
+        },
+        "etternavn": {
+          "type": "string"
+        }
+      },
+      "required": ["etternavn"],
+      "additionalProperties": false
+    },
+    "personForetak": {
+      "description": "En siktet eller fornærmet kan være en person eller et foretak, denne typen er enten person eller foretak.",
+      "type": "object",
+      "properties": {
+        "person": {
+          "$ref": "#/definitions/person"
+        },
+        "foretak": {
+          "$ref": "#/definitions/foretak"
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "person": {
+              "$ref": "#/definitions/person"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["person"]
+        },
+        {
+          "properties": {
+            "foretak": {
+              "$ref": "#/definitions/foretak"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["foretak"]
+        }
+      ]
+    },
+    "personAdresse": {
+      "description": "Kan være graderte adresser",
+      "type": "object",
+      "properties": {
+        "gradering": {
+          "$ref": "#/definitions/adresseGradering"
+        },
+        "adresse": {
+          "$ref": "#/definitions/adresse"
+        }
+      },
+      "required": ["adresse"],
+      "additionalProperties": false
+    },
+    "person": {
+      "description": "Person med alle nyttige data som fødselsnummer adresse osv., SSP nummer kun på siktede, tiltalte.",
+      "type": "object",
+      "properties": {
+        "internId": {
+          "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId",
+          "type": "string"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": {
+          "$ref": "#/definitions/date"
+        },
+        "kjoenn": {
+          "description": "Ukjent kjønn hvis denne ikke er med",
+          "$ref": "#/definitions/kjoenn"
+        },
+        "statsborgerskap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/land"
+          }
+        },
+        "identitetsnummer": {
+          "description": "Fødselsnummer, D-nummer eller SSP nummer som er den i bruk",
+          "$ref": "#/definitions/personIdentifikator"
+        },
+        "tilleggsId": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personIdentifikator"
+          },
+          "description": "Kan være SSP nummer hvis person har D-nummer, fremtidig historiske nummer?"
+        },
+        "adresseGradering": {
+          "$ref": "#/definitions/adresseGradering",
+          "description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå"
+        },
+        "personAdresse": {
+          "$ref": "#/definitions/personAdresse"
+        },
+        "verger": {
+          "type": "array",
+          "description": "Verge skal være med på siktet, fornærmet, vitne.",
+          "items": {
+            "$ref": "#/definitions/personEnkel"
+          }
+        }
+      },
+      "required": [
+        "internId",
+        "navn",
+        "foedselsdato",
+        "statsborgerskap",
+        "tilleggsId",
+        "verger"
+      ],
+      "additionalProperties": false
+    },
+    "personEnkel": {
+      "type": "object",
+      "description": "Kun navn og fødselsdato (hvis den finnes)",
+      "properties": {
+        "internId": {
+          "type": "string",
+          "description": "Intern som peker på samme person i en spesifikk melding"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": { "$ref": "#/definitions/date" }
+      },
+      "required": ["internId", "navn"],
+      "additionalProperties": false
+    },
+    "restriksjon": {
+      "description": "Restriksjon fra domstolen, når vi har mottatt den, uten til fra dato kun når det er anke",
+      "type": "object",
+      "properties": {
+        "restriksjonsId": {
+          "type": "string",
+          "description": "restriksjonsId som opprettes i DA (GUID)"
+        },
+        "restriksjonsType": {
+          "$ref": "#/definitions/restriksjonsType"
+        },
+        "fraDato": {
+          "description": "Om begjæringen ikke tas til følge er dette feltet satt til null.",
+          "$ref": "#/definitions/date"
+        },
+        "tilDato": {
+          "description": "Om begjæringen ikke tas til følge er dette feltet satt til null.",
+          "$ref": "#/definitions/date"
+        }
+      },
+      "required": ["restriksjonsId", "restriksjonsType"],
+      "additionalProperties": false
+    },
+    "restriksjonsType": {
+      "description": "Liste over de ulike restriksjonene",
+      "enum": [
+        "BREV_OG_BESOEKSFORBUD",
+        "BREV_OG_BESOEKSKONTROLL",
+        "MEDIEFORBUD"
+      ],
+      "type": "string"
+    },
+    "straffesakInvolverte": {
+      "description": "Straffesak med statistikkgrupper, krimtype og de involverte",
+      "type": "object",
+      "required": ["straffesaksnummer", "detaljer", "involverte"],
+      "additionalProperties": true,
+      "properties": {
+        "straffesaksnummer": {
+          "$ref": "#/definitions/straffesaksnummer"
+        },
+        "detaljer": { "$ref": "#/definitions/straffesakDetaljer" },
+        "involverte": { "$ref": "#/definitions/involverteStraffesak" }
+      }
+    },
+
+    "straffesakDetaljer": {
+      "type": "object",
+      "description": "Detaljer rundt straffesaken, OBS krimType er ikke klart ennå-.s",
+      "properties": {
+        "hendelse": {
+          "$ref": "#/definitions/hendelse"
+        },
+        "statistikkgruppe": {
+          "$ref": "#/definitions/kodeverk"
+        },
+        "krimtype": {
+          "$ref": "#/definitions/kodeverk"
+        }
+      },
+      "required": ["hendelse", "statistikkgruppe"],
+      "additionalProperties": false
+    },
+    "land": {
+      "type": "object",
+      "description": "ISO-3166, Kosovo kommer",
+      "properties": {
+        "kode": {
+          "type": "string",
+          "pattern": "^[A-Z]+$",
+          "minLength": 3,
+          "maxLength": 3
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["kode"],
+      "additionalProperties": false
+    },
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "straffesaksnummer": {
+      "type": "string",
+      "description": "Som regel et løpenummer, men kan i fremtiden også inneholde bokstaver",
+      "minLength": 3,
+      "maxLength": 30
+    },
+    "telefonnummer": {
+      "type": "string",
+      "description": "Ett telefonnummer, norsk eller utenlands, med eller uten land prefix",
+      "maxLength": 30,
+      "minLength": 1
+    },
+    "foedselsnummer": {
+      "type": "string",
+      "description": "Se skatteetaten. Kan være vanlig med 6 sifret fødselsdato og fiktivt (Tenor) fødselsnummer med +80 på måned slik at noen født 10.01.1990 begynner fiktivt nummer med 108190",
+      "pattern": "^[0-3][0-9][0189][0-9]+$",
+      "minLength": 11,
+      "maxLength": 11
+    },
+    "sspNummer": {
+      "type": "string",
+      "description": "Personidentifikator brukt av det sentrale straffe- og personopplysningsregisteret (SSP) hvis personen ikke har fødselsnummer. Validerer som et fødselsnummer med +20 på måned så noen født 10.01.1990 begynner med 102190",
+      "pattern": "^[0-3][0-9][2-3][0-9]+$",
+      "minLength": 11,
+      "maxLength": 11
+    },
+    "dNummer": {
+      "type": "string",
+      "description": "Se skatteetaten. Dag på datodelen er +40. Født 10.01.1990, begynner med 51.01.90. Fiktivt (Tenor) dNummer vil har +80 på måned som for Tenor fødselsnummer",
+      "pattern": "^[4-7][0-9][0189][0-9]+$",
+      "minLength": 11,
+      "maxLength": 11
+    },
+    "organisasjonsnummer": {
+      "type": "string",
+      "description": "Norsk organisasjonsnummer fra BRREG. Referanse til politistrikt, domstol, fengsel. https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/organisasjonsnummeret/",
+      "pattern": "^[0-9]+$",
+      "minLength": 9,
+      "maxLength": 9
+    }
+  }
+}

--- a/kontrakter/politi/kjennelseVaretektPoliti/1.0/kjennelseVaretektPoliti.schema.json
+++ b/kontrakter/politi/kjennelseVaretektPoliti/1.0/kjennelseVaretektPoliti.schema.json
@@ -378,8 +378,9 @@
         },
         "kravid": {
           "type": "string",
-          "description": "Kravid som opprettes i politiet"
+          "description": "Kravid som opprettes i politiet (begjæring om varetektsfengsling)"
         },
+		"forlengelse": {"type": "boolean"},
         "restriksjoner": {
           "type": "array",
           "items": {
@@ -406,6 +407,7 @@
         "avgjoerelseId",
         "avsagtDato",
         "kravid",
+		"forlengelse",
         "fengsling",
         "restriksjoner",
         "isolasjonsKrav"

--- a/kontrakter/politi/kjennelseVaretektPoliti/changelog.md
+++ b/kontrakter/politi/kjennelseVaretektPoliti/changelog.md
@@ -1,5 +1,6 @@
 # oppdaterinv av varetekt endringer
 
-## oppdeling av oppdaterVaretekt juni 2023
+## oppdeling av oppdaterVaretekt 26.06.2023
 siktelsesInfo er fjernet (kommer med siktelsesdata)
 Lagt til straffesaker som i fremtiden skal inneholde lovbud, men som nå vil inneholde bare data fra straffesaken.
+Person og foretak som vi ble enige om i forbindelse med arbeidet med løslatelsesordren.

--- a/kontrakter/politi/kjennelseVaretektPoliti/changelog.md
+++ b/kontrakter/politi/kjennelseVaretektPoliti/changelog.md
@@ -1,6 +1,18 @@
-# oppdaterinv av varetekt endringer
+# kjennelseVaretekt til Kriminalomsrogen
+| Versjon | Beskrivelse | Aktiv fra | Aktiv til |
+| --- | --- | --- | --- |
+| 1.0 | Første versjon til produksjon, pilot dato ??| | |
 
-## oppdeling av oppdaterVaretekt 26.06.2023
-siktelsesInfo er fjernet (kommer med siktelsesdata)
-Lagt til straffesaker som i fremtiden skal inneholde lovbud, men som nå vil inneholde bare data fra straffesaken.
-Person og foretak som vi ble enige om i forbindelse med arbeidet med løslatelsesordren.
+Denne meldingen sammen med [endreRestriksjoner](../endreRestriksjoner/readme.md) erstatter [oppdaterVaretekt](../oppdatervaretekt/readme.md)
+## Versjon 1.0
+Nyeste endringer øverst.
+### Første versjon 26.07.2023
+Endringsbeskrivelsen er i forhold til [oppdaterVaretekt](../oppdatervaretekt/readme.md) versjon 1.0 som vi kjørte med i brukertest juni 2023.
+
+1. siktelsesInfo er fjernet (kommer med siktelsesdata) som vi implementerer sammen med begjæring om tilståelsesdom til tingretten.
+1. Det er lagt til straffesaker som i fremtiden skal inneholde lovbud.
+1. Person og foretak som vi ble enige om i forbindelse med arbeidet med løslatelsesordren.
+1. Mer kompakt format `"internId": { "type": "string" },`
+1. Forlengelse
+1. Persondata fra domstol og fra politi, se [readme](./readme.md)
+1. Dommer og saksbehandler hos domstolen med som en del av kjennelsen

--- a/kontrakter/politi/kjennelseVaretektPoliti/changelog.md
+++ b/kontrakter/politi/kjennelseVaretektPoliti/changelog.md
@@ -1,0 +1,5 @@
+# oppdaterinv av varetekt endringer
+
+## oppdeling av oppdaterVaretekt juni 2023
+siktelsesInfo er fjernet (kommer med siktelsesdata)
+Lagt til straffesaker som i fremtiden skal inneholde lovbud, men som nå vil inneholde bare data fra straffesaken.

--- a/kontrakter/politi/kjennelseVaretektPoliti/readme.md
+++ b/kontrakter/politi/kjennelseVaretektPoliti/readme.md
@@ -2,23 +2,28 @@
 Når politiet mottar kjennelse så blir kjennelsen strukturert og med kjennelse/rettsbok PDF rutet videre til Kriminalomsorgen.
 Det skal legges ved data om straffesakene, se nedenfor.
 
-Denne meldingen skal brukes på førstegangsfengslinger og forlengelser i etterkant og den erstatter [oppdaterVaretekt](../oppdatervaretekt/readme.md) sammen med meldingen [endreRestriksjoner](../endreRestriksjoner/readme.md)
+Denne meldingen skal brukes på førstegangsfengslinger og fengslingsforlengelser og den erstatter [oppdaterVaretekt](../oppdatervaretekt/readme.md) sammen med meldingen [endreRestriksjoner](../endreRestriksjoner/readme.md)  
+Når politiet mottar en kjennelse på varetekt så blir denne meldingen sendt automatisk til Kriminalomsorgen og den vil inneholde kjennelsen strukturert og på PDF format fra domstolen samt data fra straffesaken hos politiet.
 
 [Endringslogg](changelog.md) - [RFC](../../../rfc/MessageName-header.md)
 ## Headere forsendelse justisHub
 SchmaName=KJENNELSE_VARETEKT_POLITI  
 SchemaVersion=1.0  
 
-Versjon 1.0 er første versjon som skal til pilot høsten 2023 og er en del av oppdaterVaretekt som skal utgå og erstattes av 
+Versjon 1.0 er første versjon som skal til pilot høsten 2023 og er en del av oppdaterVaretekt som skal erstattes av kjennelseVaretektPoliti og 
 ## Status - ikke godkjent
-Begge parter må være enige om innholdet før vi kan gå i produksjon.
+Begge parter må være enige om innholdet.
 ## Data
-I tillegg til forsendelse og detaljer om personen så blir følgende data med.
+### avsender og domstol
+Det er automatisk videresending av kjennelsen fra domstolen fra politiet, avsender vil være eierdistriktet for straffesaken. Informasjon om domstol, dommmer og saksbehandler kommer sammen med kjennelsen.
+### Forlengelse
+Hvis kjennelsen er et svar på en begjæring om varetekt med forlengelse.  
+**OBS** til å begynne med så er flagget forelengelse i begjæringen satt av brukerne hvis førstegangsfengslingen er gjort på gammelmåten via BL.
 ### Siktede
 Siktede fra domstolen kan være en en annen person en den som finnes på straffesaken, dvs. vi finner ikke match mellom data fra domstolen og det vi har som straffesaksdata.
-* *personVaretektInfo->personVaretekt* er personen fra straffesak hvis vi finner match mellom domstolen sin person og en siktet person på straffesaken.
-* Siktede informasjon fra domstolen finnes en kopi i kjennelsen   
-*kjennelseVaretekt->domstolPersonVaretekt*.
+* *personVaretektInfo->personVaretekt* er personen fra straffesak hvis vi finner match mellom domstolen sin person og en siktet person på straffesaken (fødselsnummer, SSP nummer, D-nummer, etternavn, fornavn), det bør alltid være match.
+* Siktede informasjon fra domstolen finnes i kjennelsen   
+*kjennelseVaretekt->personVaretektDomstol*.
 * Siktedes informasjon fra straffesaken vil finnes på: *personVaretektInfo->straffesaksInfo->siktet*
 ### Straffesaksdata
 I første omgang så kommer informasjon kun fra hovedsaken og det kommer ikke med lovbud. Når siktelsen kommer (sammen med tilståelsessaker) så vil vi kunne sende med informasjon på alle straffesaker som siktede er involvert i.
@@ -41,14 +46,18 @@ sequenceDiagram
   da->>pd:kjennelseVaretekt
   activate pd
   pd->>kdi:kjennelseVaretektPoliti
+  note right of kdi: Førstegangsfengsling
   deactivate pd
   note over pd: Varetektstiden løper ut
   pd->>da: begjaeringVaretekt
   da->>pd:kjennelseVaretekt
   activate pd
   pd->>kdi:kjennelseVaretektPoliti
+  note right of kdi: Fengslingsforlengelse
   deactivate pd
+  note over pd: etterforskning ferdig
   pd-->>kdi:endreRestriksjoner
+  note right of kdi: Trenger ikke isolasjon lenger
 ```
 * Kvitteringer skal sendes på alle meldinger og er ikke vist i diagrammet.
 * varetektsplass er tilbud på plass i et gitt fengsel, se [bestillingVaretekt](../bestillvaretektsplass/readme.md)

--- a/kontrakter/politi/kjennelseVaretektPoliti/readme.md
+++ b/kontrakter/politi/kjennelseVaretektPoliti/readme.md
@@ -14,6 +14,12 @@ Versjon 1.0 er første versjon som skal til pilot høsten 2023 og er en del av o
 Begge parter må være enige om innholdet før vi kan gå i produksjon.
 ## Data
 I tillegg til forsendelse og detaljer om personen så blir følgende data med.
+### Siktede
+Siktede fra domstolen kan være en en annen person en den som finnes på straffesaken, dvs. vi finner ikke match mellom data fra domstolen og det vi har som straffesaksdata.
+* *personVaretektInfo->personVaretekt* er personen fra straffesak hvis vi finner match mellom domstolen sin person og en siktet person på straffesaken.
+* Siktede informasjon fra domstolen finnes en kopi i kjennelsen   
+*kjennelseVaretekt->domstolPersonVaretekt*.
+* Siktedes informasjon fra straffesaken vil finnes på: *personVaretektInfo->straffesaksInfo->siktet*
 ### Straffesaksdata
 I første omgang så kommer informasjon kun fra hovedsaken og det kommer ikke med lovbud. Når siktelsen kommer (sammen med tilståelsessaker) så vil vi kunne sende med informasjon på alle straffesaker som siktede er involvert i.
 ### Data om helse, risiko og tilstand
@@ -42,10 +48,12 @@ sequenceDiagram
   activate pd
   pd->>kdi:kjennelseVaretektPoliti
   deactivate pd
+  pd-->>kdi:endreRestriksjoner
 ```
 * Kvitteringer skal sendes på alle meldinger og er ikke vist i diagrammet.
 * varetektsplass er tilbud på plass i et gitt fengsel, se [bestillingVaretekt](../bestillvaretektsplass/readme.md)
 * Innsettelsesordren er vist som et eksempel og vil bli brukt hvis kjennelsen ikke er klar til når personen skal flyttes til Kriminalomsorgen.
+* [endreRestriksjoner](../endreRestriksjoner/readme.md) så påtale kan lette på restriksjoner. Ikke planlagt når denne skal implementeres.
 ## Avklaringer
 I arbeidet med fengslinger og informasjon mellom politi og Kriminalomsorgen er det gjort noen antagelser i den nye meldingen for kjennelse fra domstolene.
 ### Straffesaksinformasn (Siktelse) og data til Kriminalomsorgen

--- a/kontrakter/politi/kjennelseVaretektPoliti/readme.md
+++ b/kontrakter/politi/kjennelseVaretektPoliti/readme.md
@@ -1,0 +1,59 @@
+# Kjennelse på varetekt videresendt til Kriminalomsorgen (kjennelseVaretektPoliti)
+Når politiet mottar kjennelse så blir kjennelsen strukturert og med kjennelse/rettsbok PDF rutet videre til Kriminalomsorgen.
+Det skal legges ved data om straffesakene, se nedenfor.
+
+Denne meldingen skal brukes på førstegangsfengslinger og forlengelser i etterkant og den erstatter [oppdaterVaretekt](../oppdatervaretekt/readme.md) sammen med meldingen [endreRestriksjoner](../endreRestriksjoner/readme.md)
+
+[Endringslogg](changelog.md)
+## Headere forsendelse justisHub
+SchmaName=KJENNELSE_VARETEKT_POLITI
+SchemaVersion=1.0  
+[RFC](../../../rfc/MessageName-header.md)
+
+Versjon 1.0 er første versjon som skal til pilot og er en del av oppdaterVaretekt som skal utgå og erstattes av 
+## Status - ikke godkjent
+Begge parter må være enige om innholdet før vi kan gå i produksjon.
+## Data
+I tillegg til forsendelse og detaljer om personen så blir følgende data med.
+### Straffesaksdata
+I første omgang så kommer informasjon kun fra hovedsaken og det kommer ikke med lovbud. Når siktelsen kommer (sammen med tilståelsessaker) så vil vi kunne sende med informasjon på alle straffesaker som siktede er involvert i.
+### Data om helse, risiko og tilstand
+[Kommer i bestillingVaretekt meldingen](../bestillvaretektsplass/readme.md) *oppdatert beskrivelse på data*
+### Det legges ikke ved PDF dokumenter fra straffesaken
+Dvs. siktelses PDF blir ikke med, se avklaring nedenfor. Kjennelsen fra domstolen på PDF format blir lagt ved oversendelsen.
+## Flyt
+```mermaid
+sequenceDiagram
+  autonumber
+  participant da as Domstol
+  Participant pd as politi
+  Participant kdi as Kriminalomsorgen
+  Note over pd: Pågripelse, <br/>innsettelse i politiarrest
+  pd->>da: begjaeringVaretekt
+  pd->>kdi:bestillingVaretekt
+  kdi->>pd:varetektPlass
+  pd-->>kdi:innsettelsesordre
+  da->>pd:kjennelseVaretekt
+  activate pd
+  pd->>kdi:kjennelseVaretektPoliti
+  deactivate pd
+  note over pd: Varetektstiden løper ut
+  pd->>da: begjaeringVaretekt
+  da->>pd:kjennelseVaretekt
+  activate pd
+  pd->>kdi:kjennelseVaretektPoliti
+  deactivate pd
+```
+* Kvitteringer skal sendes på alle meldinger og er ikke vist i diagrammet.
+* varetektsplass er tilbud på plass i et gitt fengsel, se [bestillingVaretekt](../bestillvaretektsplass/readme.md)
+* Innsettelsesordren er vist som et eksempel og vil bli brukt hvis kjennelsen ikke er klar til når personen skal flyttes til Kriminalomsorgen.
+## Avklaringer
+I arbeidet med fengslinger og informasjon mellom politi og Kriminalomsorgen er det gjort noen antagelser i den nye meldingen for kjennelse fra domstolene.
+### Straffesaksinformasn (Siktelse) og data til Kriminalomsorgen
+Kjennelsen fra domstolen inneholder ikke detaljer om siktelsen til den personen som skal varetektsfengsles og den strukturerte kjennelsen er heller ikke klar fra politiet.
+1. Siktelsesdokumentet (PDF) blir ikke med da det inneholder informasjon om andre og detaljert beskrivelse av hva som skjedde.
+### Siktelsesinformasjon til senere
+Senere så vil vi ta med siktelsesinformasjon inkludert lovbud på alle straffesaker siktede er siktet for.
+1. Grunnlagstekst er en beskrivelse av selve hendelsen, trenger Kriminalomsorgen den?
+### Kjennelse
+Det kommer småjusteringer på kjennelsen ennå.

--- a/kontrakter/politi/kjennelseVaretektPoliti/readme.md
+++ b/kontrakter/politi/kjennelseVaretektPoliti/readme.md
@@ -4,8 +4,8 @@ Det skal legges ved data om straffesakene, se nedenfor.
 
 Denne meldingen skal brukes på førstegangsfengslinger og forlengelser i etterkant og den erstatter [oppdaterVaretekt](../oppdatervaretekt/readme.md) sammen med meldingen [endreRestriksjoner](../endreRestriksjoner/readme.md)
 
-[Endringslogg](changelog.md)
-## Headere forsendelse justisHub - [RFC](../../../rfc/MessageName-header.md)
+[Endringslogg](changelog.md) - [RFC](../../../rfc/MessageName-header.md)
+## Headere forsendelse justisHub
 SchmaName=KJENNELSE_VARETEKT_POLITI  
 SchemaVersion=1.0  
 

--- a/kontrakter/politi/kjennelseVaretektPoliti/readme.md
+++ b/kontrakter/politi/kjennelseVaretektPoliti/readme.md
@@ -1,16 +1,15 @@
-# Kjennelse på varetekt videresendt til Kriminalomsorgen (kjennelseVaretektPoliti)
+# Kjennelse på varetekt til Kriminalomsorgen (kjennelseVaretektPoliti)
 Når politiet mottar kjennelse så blir kjennelsen strukturert og med kjennelse/rettsbok PDF rutet videre til Kriminalomsorgen.
 Det skal legges ved data om straffesakene, se nedenfor.
 
 Denne meldingen skal brukes på førstegangsfengslinger og forlengelser i etterkant og den erstatter [oppdaterVaretekt](../oppdatervaretekt/readme.md) sammen med meldingen [endreRestriksjoner](../endreRestriksjoner/readme.md)
 
 [Endringslogg](changelog.md)
-## Headere forsendelse justisHub
-SchmaName=KJENNELSE_VARETEKT_POLITI
+## Headere forsendelse justisHub - [RFC](../../../rfc/MessageName-header.md)
+SchmaName=KJENNELSE_VARETEKT_POLITI  
 SchemaVersion=1.0  
-[RFC](../../../rfc/MessageName-header.md)
 
-Versjon 1.0 er første versjon som skal til pilot og er en del av oppdaterVaretekt som skal utgå og erstattes av 
+Versjon 1.0 er første versjon som skal til pilot høsten 2023 og er en del av oppdaterVaretekt som skal utgå og erstattes av 
 ## Status - ikke godkjent
 Begge parter må være enige om innholdet før vi kan gå i produksjon.
 ## Data

--- a/kontrakter/politi/oppdatervaretekt/changelog.md
+++ b/kontrakter/politi/oppdatervaretekt/changelog.md
@@ -1,4 +1,4 @@
-# oppdaterinv av varetekt endringer
+# oppdatering av varetekt endringer
 
 ### Skal ikke brukes lenger 23.06.2023
 Delt opp i to meldinger [](../)

--- a/kontrakter/politi/oppdatervaretekt/changelog.md
+++ b/kontrakter/politi/oppdatervaretekt/changelog.md
@@ -1,5 +1,7 @@
 # oppdaterinv av varetekt endringer
 
+### Skal ikke brukes lenger 23.06.2023
+Delt opp i to meldinger [](../)
 ### message name skal til Header
 Fjernet message fra melding og eksempler.  
 Lagt til informasjon i [readme.md](readme.md)
@@ -7,3 +9,4 @@ Lagt til informasjon i [readme.md](readme.md)
 ### Omorganisering til like typer
 21.04.2023
 Omorganisering slik at typer er like over alle meldinger.
+

--- a/kontrakter/politi/oppdatervaretekt/readme.md
+++ b/kontrakter/politi/oppdatervaretekt/readme.md
@@ -1,5 +1,6 @@
 # Oppdatering av varetekt
 Oppdatering av varetekt når kjennelsen kommer eller når påtale letter på restriksjoner/isolasjon.
+Denne utgår og erstattes av [kjennelseVaretektPoliti](../kjennelseVaretektPoliti/readme.md) og [endreRestriksjoner](../endreRestriksjoner/readme.md)
 
 ## Headere forsendelse justisHub
 SchmaName=OPPDATER_VARETEKT  

--- a/kontrakter/politi/oppdatervaretekt/readme.md
+++ b/kontrakter/politi/oppdatervaretekt/readme.md
@@ -1,5 +1,4 @@
-# Oppdatering av varetekt
-Oppdatering av varetekt når kjennelsen kommer eller når påtale letter på restriksjoner/isolasjon.
+# Oppdatering av varetekt (utgår)
 Denne utgår og erstattes av [kjennelseVaretektPoliti](../kjennelseVaretektPoliti/readme.md) og [endreRestriksjoner](../endreRestriksjoner/readme.md)
 
 ## Headere forsendelse justisHub

--- a/kontrakter/politi/varetekt/1.1/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/1.1/begjaeringVaretekt.schema.json
@@ -268,7 +268,7 @@
           }
         }
       },
-      "required": ["person", "verger", "tolk"],
+      "required": ["person", "verger"],
       "additionalProperties": false
     },
     "spraakkodeType": {
@@ -279,7 +279,7 @@
     "behovForTolkType": {
       "type": "string",
       "description": "Er det behov for tolk",
-      "enum": ["JA_POLITIET_STILLER", "JA_DOMSTOLEN_STILLER, IKKE_BEHOV"]
+      "enum": ["JA_POLITIET_STILLER", "JA_DOMSTOLEN_STILLER"]
     },
     "varetektInfo": {
       "type": "object",

--- a/kontrakter/politi/varetekt/1.1/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/1.1/begjaeringVaretekt.schema.json
@@ -110,20 +110,9 @@
           "$ref": "#/definitions/forlengelseInfo",
           "description": "Hvis det er en forlengelse så er dette elementet med"
         },
-        "hovedforhandling": {
-          "type": "object",
-          "description": "Hvis de tror hovedforhandling kommer før varetektsfengsling er ferdig",
-          "properties": {
-            "beskrivelse": {
-              "type": "string"
-            },
-            "berammetDato": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          "required": ["beskrivelse"],
-          "additionalProperties": false
+        "hovedforhandlingsdato": {
+          "type": "string",
+          "format": "date"
         },
         "paagrepetTidspunkt": {
           "type": "string",
@@ -193,14 +182,48 @@
     },
     "fengsling": {
       "type": "object",
-      "description": "Hvor lenge i varetekt ",
+      "description": "Hvor lenge i varetekt",
+      "properties": {
+        "varighet": {
+          "$ref": "#/definitions/varighet"
+        }
+      },
+      "required": ["varighet"],
+      "additionalProperties": false
+    },
+    "varighet": {
+      "type": "object",
+      "description": "Varighet på fengsling/restriksjon, antall dager eller frem til hovedforhandling (dato satt i saksinformasjon)",
       "properties": {
         "antallDager": {
           "type": "integer"
+        },
+        "tilHovedforhandling": {
+          "type": "boolean",
+          "const": true
         }
       },
-      "required": ["antallDager"],
-      "additionalProperties": false
+      "oneOf": [
+        {
+          "properties": {
+            "antallDager": {
+              "type": "integer"
+            }
+          },
+          "required": ["antallDager"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "tilHovedforhandling": {
+              "type": "boolean",
+              "const": true
+            }
+          },
+          "required": ["tilHovedforhandling"],
+          "additionalProperties": false
+        }
+      ]
     },
     "forlengelseInfo": {
       "type": "object",
@@ -565,7 +588,7 @@
           "$ref": "#/definitions/lovbudEnkel"
         },
         "periode": {
-          "$ref": "#/definitions/periodeStartAntall"
+          "$ref": "#/definitions/periodeStartVarighet"
         }
       },
       "required": ["isolasjonsType", "lovbudEnkel", "periode"]
@@ -575,17 +598,17 @@
       "description": "Liste over de ulike isolasjonstyper",
       "enum": ["FULL_ISOLASJON", "DELVIS_ISOLASJON"]
     },
-    "periodeStartAntall": {
+    "periodeStartVarighet": {
       "type": "object",
-      "description": "Periode for fensling eller restriksjon, bruker ikke å spesifisere startdato, derfor lengde og antall dager inn i fengslingen for restriksjoner",
-      "required": ["startDag", "antallDager"],
+      "description": "Periode for isolasjon eller restriksjon, bruker ikke å spesifisere startdato, derfor lengde og antall dager inn i fengslingen for restriksjoner",
+      "required": ["startDag", "varighet"],
       "additionalProperties": false,
       "properties": {
         "startDag": {
           "type": "integer"
         },
-        "antallDager": {
-          "type": "integer"
+        "varighet": {
+          "$ref": "#/definitions/varighet"
         }
       }
     },
@@ -601,7 +624,7 @@
           "$ref": "#/definitions/lovbudEnkel"
         },
         "periode": {
-          "$ref": "#/definitions/periodeStartAntall"
+          "$ref": "#/definitions/periodeStartVarighet"
         }
       }
     },

--- a/kontrakter/politi/varetekt/1.1/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/1.1/begjaeringVaretekt.schema.json
@@ -1274,23 +1274,6 @@
       "required": ["internId"],
       "additionalProperties": false
     },
-    "land": {
-      "type": "object",
-      "description": "ISO-3166, Kosovo kommer",
-      "properties": {
-        "kode": {
-          "type": "string",
-          "pattern": "^[A-Z]+$",
-          "minLength": 3,
-          "maxLength": 3
-        },
-        "navn": {
-          "type": "string"
-        }
-      },
-      "required": ["kode"],
-      "additionalProperties": false
-    },
     "organisasjonsnummer": {
       "type": "string",
       "description": "Norsk organisasjonsnummer fra BRREG. Referanse til politistrikt, domstol, fengsel. https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/organisasjonsnummeret/",

--- a/kontrakter/politi/varetekt/1.1/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/1.1/begjaeringVaretekt.schema.json
@@ -1274,6 +1274,23 @@
       "required": ["internId"],
       "additionalProperties": false
     },
+    "land": {
+      "type": "object",
+      "description": "ISO-3166, Kosovo kommer",
+      "properties": {
+        "kode": {
+          "type": "string",
+          "pattern": "^[A-Z]+$",
+          "minLength": 3,
+          "maxLength": 3
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["kode"],
+      "additionalProperties": false
+    },
     "organisasjonsnummer": {
       "type": "string",
       "description": "Norsk organisasjonsnummer fra BRREG. Referanse til politistrikt, domstol, fengsel. https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/organisasjonsnummeret/",

--- a/kontrakter/politi/varetekt/1.1/eksempelfiler/begjaeringVaretekt-eksempel-1.json
+++ b/kontrakter/politi/varetekt/1.1/eksempelfiler/begjaeringVaretekt-eksempel-1.json
@@ -65,7 +65,9 @@
       },
       "paastandVaretekt": {
         "fengsling": {
-          "antallDager": 28
+          "varighet": {
+            "antallDager": 28
+          }
         },
         "restriksjoner": [
           {
@@ -75,7 +77,9 @@
             },
             "periode": {
               "startDag": 1,
-              "antallDager": 14
+              "varighet": {
+                "antallDager": 14
+              }
             }
           },
           {
@@ -85,7 +89,9 @@
             },
             "periode": {
               "startDag": 15,
-              "antallDager": 14
+              "varighet": {
+                "antallDager": 14
+              }
             }
           }
         ],
@@ -97,7 +103,9 @@
             },
             "periode": {
               "startDag": 1,
-              "antallDager": 14
+              "varighet": {
+                "tilHovedforhandling": true
+              }
             }
           }
         ]
@@ -127,10 +135,6 @@
       "varetektsType": "VANLIG",
       "forlengelse": {
         "beskrivelse": "forlengelse"
-      },
-      "hovedforhandling": {
-        "beskrivelse": "Påtalemyndigheten har som mål å beramme hovedforhandling før varetektsperioden utløper, hovedforhandling starter ..",
-        "berammetDato": "2023-04-09"
       },
       "paagrepetTidspunkt": "2023-02-28T17:21:27+02:00",
       "berammetFengslingsmoete": {

--- a/kontrakter/politi/varetekt/changelog.md
+++ b/kontrakter/politi/varetekt/changelog.md
@@ -6,6 +6,9 @@
 ## Versjon 1.1 - pilot 2023
 ### Oppdatert begrense offentlighet
 Kan velge flere krav under begrense offentlighet, samt lagt til HEMMELIGHOLD som alternativ
+### Varetekt til hovedforhandlingsdato
+Saksinformasjon inneholder hovedforhandlingsdato, og fengsling, restriksjoner og isolasjon inneholder en ny definisjon - varighet. 
+Varighet defineres ved å enten spesifisere antall dager i varetekt eller til hovedforhandling.
 
 Endringer fra brukertest til pilot, her er noen endringer som kommer:
 1. Tolk.

--- a/kontrakter/politi/varetekt/readme.md
+++ b/kontrakter/politi/varetekt/readme.md
@@ -3,17 +3,19 @@ Denne meldingen brukes av politiet når de skal begjære om varetekt til en ting
 Det legges ved sakstyrende dokumenter som vedlegg til denne meldingen. Restene av dokumentene (politdokumentene) kommer som en sammenstilling med kobling
 til riktig begjæring om varetekt (kravId). Sammenstillingen lages vha. BL Straffesaksforsendelse.
 ## Headere forsendelse justisHub
-SchemaName=BEGJAERING_VARETEKT
-SchemaVersion=1.0
+SchemaName=BEGJAERING_VARETEKT  
+SchemaVersion=1.1  
 [RFC](../../../rfc/MessageName-header.md)
 
+### [Se changelog for endringer](./changelog.md)
+
 ## Status på data som politiet klarer å fylle ut i dag
-Det er ikke med siktelse.
-Det er ikke med verger.
-Det er ikke med aktor.
-Det er ikke mulig i varetekt å sende begjæring om varetekt med grunn vilkårsbrudd.
-Dokumenter får ikke med dokumentkategori
-Forlengelse har ikke med noen referanse til forrige fengsling.
+* Det er ikke med siktelse.
+* Det er ikke med aktor.
+* Det er ikke mulig i varetekt å sende begjæring om varetekt med grunn vilkårsbrudd.
+* Dokumenter får ikke med dokumentkategori
+* Forlengelse har ikke med noen referanse til forrige fengsling.
+* berammetFengslingsmoete er ikke implementert
 
 ## Data endringer som ikke er med i JSON Schema
 ### Begrenset offentlighet

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <modules>
         <module>kontrakter/politi/varetekt</module>
         <module>kontrakter/politi/oppdatervaretekt</module>
+        <module>kontrakter/politi/bestillvaretektsplass</module>
         <module>kontrakter/da/varetekt</module>
         <module>kontrakter/felles/kvittering</module>
         <module>kodeverk/felles</module>

--- a/validateJsonSchema.js
+++ b/validateJsonSchema.js
@@ -7,8 +7,8 @@ addFormats(ajv);
 
 const jsonSchemaFolders = [
   "kontrakter/politi/varetekt",
+  "kontrakter/politi/kjennelseVaretektPoliti",
   "kontrakter/politi/bestillvaretektsplass",
-  "kontrakter/politi/oppdatervaretekt",
   "kontrakter/politi/innsettelsesordre",
   "kontrakter/da/varetekt",
   "kontrakter/felles/kvittering",


### PR DESCRIPTION
Oppdater varetekt er delt i to og vi implementerer en til pilot og det er kjennelseVaretektPoliti som er videresendelse av varetektskjennelser fra domstolene.
Dokumentasjonen for ny melding kjennelseVaretektPoliti beskriver inneholdet og bruken av kjennelseVaretektPoliti.