### PR TITLE
STRAFF2-718 Opprett KjennelseVaretekt v1.1

### DIFF
--- a/kontrakter/da/varetekt/1.0/KjennelseVaretekt.schema.json
+++ b/kontrakter/da/varetekt/1.0/KjennelseVaretekt.schema.json
@@ -2,7 +2,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://domstol.no/da/varetekt/1.0/KjennelseVaretekt.schema.json",
   "description": "Schema definisjon av en Kjennelse-varetekt",
-
   "properties": {
     "forsendelse": {
       "$ref": "#/definitions/forsendelse"
@@ -28,7 +27,9 @@
     },
     "dokumenter": {
       "type": "array",
-      "items": { "$ref": "#/definitions/dokument" }
+      "items": {
+        "$ref": "#/definitions/dokument"
+      }
     },
     "saksInformasjon": {
       "$ref": "#/definitions/saksInformasjon"
@@ -89,11 +90,15 @@
         },
         "restriksjoner": {
           "type": "array",
-          "items": { "$ref": "#/definitions/restriksjon" }
+          "items": {
+            "$ref": "#/definitions/restriksjon"
+          }
         },
         "isolasjonsKrav": {
           "type": "array",
-          "items": { "$ref": "#/definitions/isolasjon" }
+          "items": {
+            "$ref": "#/definitions/isolasjon"
+          }
         },
         "fengsling": {
           "$ref": "#/definitions/fengsling"
@@ -185,7 +190,6 @@
       "type": "object",
       "additionalProperties": false
     },
-
     "lovbud": {
       "properties": {
         "lovbudStreng": {
@@ -225,10 +229,19 @@
     },
     "forsendelse": {
       "properties": {
-        "meldingsId": { "type": "string" },
-        "sendtTid": { "type": "string", "format": "date-time" },
-        "avsender": { "$ref": "#/definitions/avsender" },
-        "mottaker": { "$ref": "#/definitions/mottaker" },
+        "meldingsId": {
+          "type": "string"
+        },
+        "sendtTid": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "avsender": {
+          "$ref": "#/definitions/avsender"
+        },
+        "mottaker": {
+          "$ref": "#/definitions/mottaker"
+        },
         "rettelse": {
           "type": "boolean",
           "description": "Settes til true dersom det er en menneskelig endring av en tidligere kjennelse. (Dersom meldingen er resendt av tekniske årsaker vil denne stå som false)",
@@ -247,7 +260,9 @@
     },
     "avsender": {
       "properties": {
-        "organisasjon": { "$ref": "#/definitions/organisasjon" },
+        "organisasjon": {
+          "$ref": "#/definitions/organisasjon"
+        },
         "person": {
           "description": "Person som sender meldingen. Vanligvis dommeren eller saksbehandleren",
           "$ref": "#/definitions/ansattPerson"
@@ -259,7 +274,9 @@
     },
     "mottaker": {
       "properties": {
-        "organisasjon": { "$ref": "#/definitions/organisasjon" }
+        "organisasjon": {
+          "$ref": "#/definitions/organisasjon"
+        }
       },
       "required": ["organisasjon"],
       "type": "object",
@@ -312,36 +329,49 @@
       "type": "object",
       "additionalProperties": false
     },
-
     "dokumentforsendelse": {
       "description": "Detaljer om lokasjon og type",
       "properties": {
-        "mimeType": { "type": "string" },
-        "sjekksum": { "type": "string" },
-        "uri": { "type": "string" }
+        "mimeType": {
+          "type": "string"
+        },
+        "sjekksum": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
       },
       "required": ["mimeType", "sjekksum", "uri"],
       "type": "object",
       "additionalProperties": false
     },
-
     "ansattPerson": {
       "description": "Type for personer som er ansatt hos påtale eller domstolen(saksbehandlere, påtaleadvokater, statsadvokater,...)",
       "properties": {
-        "etternavn": { "type": "string" },
-        "fornavn": { "type": "string" },
-        "tittel": { "type": "string" }
+        "etternavn": {
+          "type": "string"
+        },
+        "fornavn": {
+          "type": "string"
+        },
+        "tittel": {
+          "type": "string"
+        }
       },
       "required": ["etternavn"],
       "type": "object",
       "additionalProperties": false
     },
-
     "privatPerson": {
       "description": "Person som har en rolle i en straffesak (siktet, mistenkt, osv) der det er krav om fødselsnummer for nordmenn. Andre identifikatorer kan være interne, DUF nummer, pass nummer ...",
       "properties": {
-        "etternavn": { "type": "string" },
-        "fornavn": { "type": "string" },
+        "etternavn": {
+          "type": "string"
+        },
+        "fornavn": {
+          "type": "string"
+        },
         "identitetsnummer": {
           "$ref": "#/definitions/personIdentifikator",
           "description": "Fødselsnummer, D-nummer eller SSP nummer. Alle personer som det er foretatt tvangsmidler mot skal ha et D-nummer eller fødselsnummer. Dersom politiet ikke har et slikt nummer vil de generere ett 'SSP nummer'"
@@ -379,7 +409,9 @@
           "minLength": 3,
           "maxLength": 3
         },
-        "navn": { "type": "string" }
+        "navn": {
+          "type": "string"
+        }
       },
       "required": ["kode"]
     },
@@ -387,9 +419,15 @@
       "description": "Fødselsnummer, D-nummer eller SSP nummer.",
       "type": "object",
       "properties": {
-        "foedselsnummer": { "$ref": "#/definitions/foedselsnummer" },
-        "sspNummer": { "$ref": "#/definitions/sspNummer" },
-        "dNummer": { "$ref": "#/definitions/dNummer" }
+        "foedselsnummer": {
+          "$ref": "#/definitions/foedselsnummer"
+        },
+        "sspNummer": {
+          "$ref": "#/definitions/sspNummer"
+        },
+        "dNummer": {
+          "$ref": "#/definitions/dNummer"
+        }
       },
       "oneOf": [
         {
@@ -404,14 +442,18 @@
         },
         {
           "properties": {
-            "sspNummer": { "$ref": "#/definitions/sspNummer" }
+            "sspNummer": {
+              "$ref": "#/definitions/sspNummer"
+            }
           },
           "required": ["sspNummer"],
           "additionalProperties": false
         },
         {
           "properties": {
-            "dNummer": { "$ref": "#/definitions/dNummer" }
+            "dNummer": {
+              "$ref": "#/definitions/dNummer"
+            }
           },
           "required": ["dNummer"],
           "additionalProperties": false
@@ -436,11 +478,14 @@
       "minLength": 11,
       "maxLength": 11
     },
-
     "kodeverk": {
       "properties": {
-        "kode": { "type": "string" },
-        "navn": { "type": "string" }
+        "kode": {
+          "type": "string"
+        },
+        "navn": {
+          "type": "string"
+        }
       },
       "type": "object",
       "required": ["kode"],

--- a/kontrakter/da/varetekt/1.1/KjennelseVaretekt.schema.json
+++ b/kontrakter/da/varetekt/1.1/KjennelseVaretekt.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://domstol.no/da/varetekt/arbeidsversjon/KjennelseVaretekt.schema.json",
+  "$id": "https://domstol.no/da/varetekt/1.1/KjennelseVaretekt.schema.json",
   "description": "Schema definisjon av en Kjennelse-varetekt",
   "properties": {
     "forsendelse": {

--- a/kontrakter/da/varetekt/1.1/eksempelfiler/eksempel_kjennelseVaretektsfengsling.json
+++ b/kontrakter/da/varetekt/1.1/eksempelfiler/eksempel_kjennelseVaretektsfengsling.json
@@ -1,0 +1,113 @@
+{
+  "forsendelse": {
+    "meldingsId": "2CB6929E-DE3F-49A4-8AE3-9625640DF0AA",
+    "sendtTid": "2022-07-06T16:35:00+02:00",
+    "avsender": {
+      "organisasjon": {
+        "organisasjonsnummer": "826726342",
+        "navn": "Buskerud tingrett"
+      },
+      "person": {
+        "etternavn": "Saksbehandler",
+        "fornavn": "Litt",
+        "tittel": "Saksbehandler"
+      }
+    },
+    "mottaker": {
+      "organisasjon": {
+        "organisasjonsnummer": "983997953",
+        "navn": "Innlandet politidistrikt"
+      }
+    },
+    "rettelse": false
+  },
+  "aktoerer": {
+    "dommer": {
+      "etternavn": "Dommersen",
+      "fornavn": "Lars",
+      "tittel": "Dommerfullmeltig"
+    },
+    "saksbehandler": {
+      "etternavn": "Saksbehandler",
+      "fornavn": "Litt",
+      "tittel": "Saksbehandler"
+    }
+  },
+  "siktede": {
+    "identitetsnummer": {
+      "foedselsnummer": "14846399381"
+    },
+    "tilleggsId": [],
+    "fornavn": "Morsom",
+    "etternavn": "Kivi",
+    "kjoenn": "MANN",
+    "foedselsdato": "1963-04-14",
+    "nasjonalitet": {
+      "kode": "NOR",
+      "navn": "Norge"
+    }
+  },
+  "dokumenter": [
+    {
+      "internId": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb",
+      "forsendelse": {
+        "mimeType": "application/pdf",
+        "sjekksum": "1a2eced0-5792-4431-ae5c-ba0942c7e7ac",
+        "uri": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb"
+      },
+      "overskrift": "Rettsbok varetektsfengsling",
+      "skrevetDato": "2022-07-06",
+      "kategori": {
+        "kode": "DOKUMENTKATEGORI#RETTSBOK#1900-01-01",
+        "navn": "Rettsbok"
+      }
+    }
+  ],
+  "saksInformasjon": {
+    "saksnummer": "22-025462ENE-TBUS/TDRA",
+    "straffesaksnummer": "15434820",
+    "rettsmoeteTidFra": "2022-07-06T10:00:00+02:00",
+    "rettsmoeteTidTil": "2022-07-06T14:00:00+02:00",
+    "avgjoerelse": {
+      "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
+      "avsagtDato": "2022-07-05",
+      "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
+      "restriksjoner": [
+        {
+          "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
+          "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
+          "fraDato": "2022-07-06",
+          "tilDato": "2022-07-20"
+        },
+        {
+          "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
+          "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
+          "fraDato": "2022-07-21",
+          "tilDato": "2022-08-06"
+        }
+      ],
+      "isolasjonsKrav": [
+        {
+          "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
+          "isolasjonsType": "FULL",
+          "fraDato": "2022-07-06",
+          "tilDato": "2022-08-06"
+        }
+      ],
+      "fengsling": {
+        "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888",
+        "fraDato": "2022-07-06",
+        "tilDato": "2022-08-06",
+        "fengslingsFristDato": "2022-07-06",
+        "lovbud": {
+          "lovbudStreng": "strpl § 184, jf. § 185, jf. § 171 nr. 2"
+        },
+        "merknad": "Kiwi må i varetekt så fort som fy"
+      },
+      "anke": {
+        "anketDato": "2022-07-06",
+        "oppsettendeVirkning": false
+      }
+    }
+  }
+}

--- a/kontrakter/da/varetekt/1.1/eksempelfiler/eksempel_kjennelseVaretektsfengsling_ingen_fengsling_anket.json
+++ b/kontrakter/da/varetekt/1.1/eksempelfiler/eksempel_kjennelseVaretektsfengsling_ingen_fengsling_anket.json
@@ -1,0 +1,85 @@
+{
+  "forsendelse": {
+    "meldingsId": "2CB6929E-DE3F-49A4-8AE3-9625640DF0AA",
+    "sendtTid": "2022-07-06T16:35:00+02:00",
+    "avsender": {
+      "organisasjon": {
+        "organisasjonsnummer": "826726342",
+        "navn": "Buskerud tingrett"
+      },
+      "person": {
+        "etternavn": "Saksbehandler",
+        "fornavn": "Litt",
+        "tittel": "Saksbehandler"
+      }
+    },
+    "mottaker": {
+      "organisasjon": {
+        "organisasjonsnummer": "983997953",
+        "navn": "Innlandet politidistrikt"
+      }
+    },
+    "rettelse": false
+  },
+  "aktoerer": {
+    "dommer": {
+      "etternavn": "Dommersen",
+      "fornavn": "Lars",
+      "tittel": "Dommerfullmeltig"
+    },
+    "saksbehandler": {
+      "etternavn": "Saksbehandler",
+      "fornavn": "Litt",
+      "tittel": "Saksbehandler"
+    }
+  },
+  "siktede": {
+    "identitetsnummer": {
+      "foedselsnummer": "14846399381"
+    },
+    "tilleggsId": [],
+    "fornavn": "Morsom",
+    "etternavn": "Kivi",
+    "foedselsdato": "1963-04-14",
+    "nasjonalitet": {
+      "kode": "NOR",
+      "navn": "Norge"
+    }
+  },
+  "dokumenter": [
+    {
+      "internId": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb",
+      "forsendelse": {
+        "mimeType": "application/pdf",
+        "sjekksum": "1a2eced0-5792-4431-ae5c-ba0942c7e7ac",
+        "uri": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb"
+      },
+      "overskrift": "Rettsbok varetektsfengsling",
+      "skrevetDato": "2022-07-06",
+      "kategori": {
+        "kode": "DOKUMENTKATEGORI#RETTSBOK#1900-01-01",
+        "navn": "Rettsbok"
+      }
+    }
+  ],
+  "saksInformasjon": {
+    "saksnummer": "22-025462ENE-TBUS/TDRA",
+    "straffesaksnummer": "15434820",
+    "rettsmoeteTidFra": "2022-07-06T10:00:00+02:00",
+    "rettsmoeteTidTil": "2022-07-06T14:00:00+02:00",
+    "avgjoerelse": {
+      "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
+      "avsagtDato": "2022-07-05",
+      "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
+      "restriksjoner": [],
+      "isolasjonsKrav": [],
+      "fengsling": {
+        "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888"
+      },
+      "anke": {
+        "anketDato": "2022-07-06",
+        "oppsettendeVirkning": true
+      }
+    }
+  }
+}

--- a/kontrakter/da/varetekt/1.1/eksempelfiler/eksempel_kjennelseVaretektsfengsling_isolasjon.json
+++ b/kontrakter/da/varetekt/1.1/eksempelfiler/eksempel_kjennelseVaretektsfengsling_isolasjon.json
@@ -1,0 +1,99 @@
+{
+  "forsendelse": {
+    "meldingsId": "2CB6929E-DE3F-49A4-8AE3-9625640DF0AA",
+    "sendtTid": "2022-07-06T16:35:00+02:00",
+    "avsender": {
+      "organisasjon": {
+        "organisasjonsnummer": "826726342",
+        "navn": "Buskerud tingrett"
+      },
+      "person": {
+        "etternavn": "Saksbehandler",
+        "fornavn": "Litt",
+        "tittel": "Saksbehandler"
+      }
+    },
+    "mottaker": {
+      "organisasjon": {
+        "organisasjonsnummer": "983997953",
+        "navn": "Innlandet politidistrikt"
+      }
+    },
+    "rettelse": false
+  },
+  "aktoerer": {
+    "dommer": {
+      "etternavn": "Dommersen",
+      "fornavn": "Lars",
+      "tittel": "Dommerfullmeltig"
+    },
+    "saksbehandler": {
+      "etternavn": "Saksbehandler",
+      "fornavn": "Litt",
+      "tittel": "Saksbehandler"
+    }
+  },
+  "siktede": {
+    "identitetsnummer": {
+      "foedselsnummer": "14846399381"
+    },
+    "tilleggsId": [],
+    "fornavn": "Morsom",
+    "etternavn": "Kivi",
+    "foedselsdato": "1963-04-14",
+    "nasjonalitet": {
+      "kode": "NOR",
+      "navn": "Norge"
+    }
+  },
+  "dokumenter": [
+    {
+      "internId": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb",
+      "forsendelse": {
+        "mimeType": "application/pdf",
+        "sjekksum": "1a2eced0-5792-4431-ae5c-ba0942c7e7ac",
+        "uri": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb"
+      },
+      "overskrift": "Rettsbok varetektsfengsling",
+      "skrevetDato": "2022-07-06",
+      "kategori": {
+        "kode": "DOKUMENTKATEGORI#RETTSBOK#1900-01-01",
+        "navn": "Rettsbok"
+      }
+    }
+  ],
+  "saksInformasjon": {
+    "saksnummer": "22-025462ENE-TBUS/TDRA",
+    "straffesaksnummer": "15434820",
+    "rettsmoeteTidFra": "2022-07-06T10:00:00+02:00",
+    "rettsmoeteTidTil": "2022-07-06T14:00:00+02:00",
+    "avgjoerelse": {
+      "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
+      "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
+      "avsagtDato": "2022-07-05",
+      "restriksjoner": [],
+      "isolasjonsKrav": [
+        {
+          "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
+          "isolasjonsType": "FULL",
+          "fraDato": "2022-07-06",
+          "tilDato": "2022-08-06"
+        }
+      ],
+      "fengsling": {
+        "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888",
+        "fraDato": "2022-07-06",
+        "tilDato": "2022-08-06",
+        "fengslingsFristDato": "2022-07-06",
+        "lovbud": {
+          "lovbudStreng": "strpl § 184, jf. § 185, jf. § 171 nr. 2"
+        },
+        "merknad": "Kiwi må i varetekt så fort som fy"
+      },
+      "anke": {
+        "anketDato": "2022-07-06",
+        "oppsettendeVirkning": false
+      }
+    }
+  }
+}

--- a/kontrakter/da/varetekt/1.1/eksempelfiler/eksempel_kjennelseVaretektsfengsling_restriksjoner.json
+++ b/kontrakter/da/varetekt/1.1/eksempelfiler/eksempel_kjennelseVaretektsfengsling_restriksjoner.json
@@ -1,0 +1,101 @@
+{
+  "forsendelse": {
+    "meldingsId": "2CB6929E-DE3F-49A4-8AE3-9625640DF0AA",
+    "sendtTid": "2022-07-06T16:35:00+02:00",
+    "avsender": {
+      "organisasjon": {
+        "organisasjonsnummer": "826726342",
+        "navn": "Buskerud tingrett"
+      },
+      "person": {
+        "etternavn": "Saksbehandler",
+        "fornavn": "Litt",
+        "tittel": "Saksbehandler"
+      }
+    },
+    "mottaker": {
+      "organisasjon": {
+        "organisasjonsnummer": "983997953",
+        "navn": "Innlandet politidistrikt"
+      }
+    },
+    "rettelse": false
+  },
+  "aktoerer": {
+    "dommer": {
+      "etternavn": "Dommersen",
+      "fornavn": "Lars",
+      "tittel": "Dommerfullmeltig"
+    },
+    "saksbehandler": {
+      "etternavn": "Saksbehandler",
+      "fornavn": "Litt",
+      "tittel": "Saksbehandler"
+    }
+  },
+  "siktede": {
+    "identitetsnummer": {
+      "foedselsnummer": "14846399381"
+    },
+    "tilleggsId": [],
+    "fornavn": "Morsom",
+    "etternavn": "Kivi",
+    "foedselsdato": "1963-04-14",
+    "nasjonalitet": {
+      "kode": "NOR",
+      "navn": "Norge"
+    }
+  },
+  "dokumenter": [
+    {
+      "internId": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb",
+      "forsendelse": {
+        "mimeType": "application/pdf",
+        "sjekksum": "1a2eced0-5792-4431-ae5c-ba0942c7e7ac",
+        "uri": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb"
+      },
+      "overskrift": "Rettsbok varetektsfengsling",
+      "skrevetDato": "2022-07-06",
+      "kategori": {
+        "kode": "DOKUMENTKATEGORI#RETTSBOK#1900-01-01",
+        "navn": "Rettsbok"
+      }
+    }
+  ],
+  "saksInformasjon": {
+    "saksnummer": "22-025462ENE-TBUS/TDRA",
+    "straffesaksnummer": "15434820",
+    "rettsmoeteTidFra": "2022-07-06T10:00:00+02:00",
+    "rettsmoeteTidTil": "2022-07-06T14:00:00+02:00",
+    "avgjoerelse": {
+      "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
+      "avsagtDato": "2022-07-05",
+      "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
+      "restriksjoner": [
+        {
+          "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
+          "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
+          "fraDato": "2022-07-06",
+          "tilDato": "2022-07-20"
+        },
+        {
+          "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
+          "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
+          "fraDato": "2022-07-21",
+          "tilDato": "2022-08-06"
+        }
+      ],
+      "isolasjonsKrav": [],
+      "fengsling": {
+        "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888",
+        "fraDato": "2022-07-06",
+        "tilDato": "2022-08-06",
+        "fengslingsFristDato": "2022-07-06",
+        "lovbud": {
+          "lovbudStreng": "strpl § 184, jf. § 185, jf. § 171 nr. 2"
+        },
+        "merknad": "Kiwi må i varetekt så fort som fy"
+      }
+    }
+  }
+}

--- a/kontrakter/da/varetekt/1.1/eksempelfiler/eksempel_kjennelseVaretektsfengsling_uten_rettsmoete.json
+++ b/kontrakter/da/varetekt/1.1/eksempelfiler/eksempel_kjennelseVaretektsfengsling_uten_rettsmoete.json
@@ -1,0 +1,111 @@
+{
+  "forsendelse": {
+    "meldingsId": "2CB6929E-DE3F-49A4-8AE3-9625640DF0AA",
+    "sendtTid": "2022-07-06T16:35:00+02:00",
+    "avsender": {
+      "organisasjon": {
+        "organisasjonsnummer": "826726342",
+        "navn": "Buskerud tingrett"
+      },
+      "person": {
+        "etternavn": "Saksbehandler",
+        "fornavn": "Litt",
+        "tittel": "Saksbehandler"
+      }
+    },
+    "mottaker": {
+      "organisasjon": {
+        "organisasjonsnummer": "983997953",
+        "navn": "Innlandet politidistrikt"
+      }
+    },
+    "rettelse": false
+  },
+  "aktoerer": {
+    "dommer": {
+      "etternavn": "Dommersen",
+      "fornavn": "Lars",
+      "tittel": "Dommerfullmeltig"
+    },
+    "saksbehandler": {
+      "etternavn": "Saksbehandler",
+      "fornavn": "Litt",
+      "tittel": "Saksbehandler"
+    }
+  },
+  "siktede": {
+    "identitetsnummer": {
+      "foedselsnummer": "14846399381"
+    },
+    "tilleggsId": [],
+    "fornavn": "Morsom",
+    "etternavn": "Kivi",
+    "kjoenn": "MANN",
+    "foedselsdato": "1963-04-14",
+    "nasjonalitet": {
+      "kode": "NOR",
+      "navn": "Norge"
+    }
+  },
+  "dokumenter": [
+    {
+      "internId": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb",
+      "forsendelse": {
+        "mimeType": "application/pdf",
+        "sjekksum": "1a2eced0-5792-4431-ae5c-ba0942c7e7ac",
+        "uri": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb"
+      },
+      "overskrift": "Rettsbok varetektsfengsling",
+      "skrevetDato": "2022-07-06",
+      "kategori": {
+        "kode": "DOKUMENTKATEGORI#RETTSBOK#1900-01-01",
+        "navn": "Rettsbok"
+      }
+    }
+  ],
+  "saksInformasjon": {
+    "saksnummer": "22-025462ENE-TBUS/TDRA",
+    "straffesaksnummer": "15434820",
+    "avgjoerelse": {
+      "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
+      "avsagtDato": "2022-07-05",
+      "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
+      "restriksjoner": [
+        {
+          "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
+          "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
+          "fraDato": "2022-07-06",
+          "tilDato": "2022-07-20"
+        },
+        {
+          "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
+          "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
+          "fraDato": "2022-07-21",
+          "tilDato": "2022-08-06"
+        }
+      ],
+      "isolasjonsKrav": [
+        {
+          "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
+          "isolasjonsType": "FULL",
+          "fraDato": "2022-07-06",
+          "tilDato": "2022-08-06"
+        }
+      ],
+      "fengsling": {
+        "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888",
+        "fraDato": "2022-07-06",
+        "tilDato": "2022-08-06",
+        "fengslingsFristDato": "2022-07-06",
+        "lovbud": {
+          "lovbudStreng": "strpl § 184, jf. § 185, jf. § 171 nr. 2"
+        },
+        "merknad": "Kiwi må i varetekt så fort som fy"
+      },
+      "anke": {
+        "anketDato": "2022-07-06",
+        "oppsettendeVirkning": false
+      }
+    }
+  }
+}

--- a/kontrakter/da/varetekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengsling_uten_rettsmoete.json
+++ b/kontrakter/da/varetekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengsling_uten_rettsmoete.json
@@ -1,0 +1,111 @@
+{
+  "forsendelse": {
+    "meldingsId": "2CB6929E-DE3F-49A4-8AE3-9625640DF0AA",
+    "sendtTid": "2022-07-06T16:35:00+02:00",
+    "avsender": {
+      "organisasjon": {
+        "organisasjonsnummer": "826726342",
+        "navn": "Buskerud tingrett"
+      },
+      "person": {
+        "etternavn": "Saksbehandler",
+        "fornavn": "Litt",
+        "tittel": "Saksbehandler"
+      }
+    },
+    "mottaker": {
+      "organisasjon": {
+        "organisasjonsnummer": "983997953",
+        "navn": "Innlandet politidistrikt"
+      }
+    },
+    "rettelse": false
+  },
+  "aktoerer": {
+    "dommer": {
+      "etternavn": "Dommersen",
+      "fornavn": "Lars",
+      "tittel": "Dommerfullmeltig"
+    },
+    "saksbehandler": {
+      "etternavn": "Saksbehandler",
+      "fornavn": "Litt",
+      "tittel": "Saksbehandler"
+    }
+  },
+  "siktede": {
+    "identitetsnummer": {
+      "foedselsnummer": "14846399381"
+    },
+    "tilleggsId": [],
+    "fornavn": "Morsom",
+    "etternavn": "Kivi",
+    "kjoenn": "MANN",
+    "foedselsdato": "1963-04-14",
+    "nasjonalitet": {
+      "kode": "NOR",
+      "navn": "Norge"
+    }
+  },
+  "dokumenter": [
+    {
+      "internId": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb",
+      "forsendelse": {
+        "mimeType": "application/pdf",
+        "sjekksum": "1a2eced0-5792-4431-ae5c-ba0942c7e7ac",
+        "uri": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb"
+      },
+      "overskrift": "Rettsbok varetektsfengsling",
+      "skrevetDato": "2022-07-06",
+      "kategori": {
+        "kode": "DOKUMENTKATEGORI#RETTSBOK#1900-01-01",
+        "navn": "Rettsbok"
+      }
+    }
+  ],
+  "saksInformasjon": {
+    "saksnummer": "22-025462ENE-TBUS/TDRA",
+    "straffesaksnummer": "15434820",
+    "avgjoerelse": {
+      "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
+      "avsagtDato": "2022-07-05",
+      "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
+      "restriksjoner": [
+        {
+          "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
+          "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
+          "fraDato": "2022-07-06",
+          "tilDato": "2022-07-20"
+        },
+        {
+          "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
+          "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
+          "fraDato": "2022-07-21",
+          "tilDato": "2022-08-06"
+        }
+      ],
+      "isolasjonsKrav": [
+        {
+          "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
+          "isolasjonsType": "FULL",
+          "fraDato": "2022-07-06",
+          "tilDato": "2022-08-06"
+        }
+      ],
+      "fengsling": {
+        "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888",
+        "fraDato": "2022-07-06",
+        "tilDato": "2022-08-06",
+        "fengslingsFristDato": "2022-07-06",
+        "lovbud": {
+          "lovbudStreng": "strpl § 184, jf. § 185, jf. § 171 nr. 2"
+        },
+        "merknad": "Kiwi må i varetekt så fort som fy"
+      },
+      "anke": {
+        "anketDato": "2022-07-06",
+        "oppsettendeVirkning": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
Lager ny versjon av KjennelseVaretekt hvor `rettsmoeteTid(Fra|Til)` er optional.

- Oppretter `kontrakter/da/varetekt/1.1/KjennelseVaretekt.schema.json`
- Legger til eksempel uten rettsmøte
- Formaterer med Prettier