### PR TITLE
ESAS-850: oppdatert periodeStartVarighet med periodeStart og startDato

### DIFF
--- a/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
@@ -49,12 +49,7 @@
           "$ref": "#/definitions/saksinformasjon"
         }
       },
-      "required": [
-        "kravId",
-        "siktet",
-        "varetekt",
-        "saksinformasjon"
-      ],
+      "required": ["kravId", "siktet", "varetekt", "saksinformasjon"],
       "additionalProperties": false
     },
     "vedlegg": {
@@ -78,19 +73,13 @@
           }
         }
       },
-      "required": [
-        "straffesaker",
-        "dokumenter"
-      ],
+      "required": ["straffesaker", "dokumenter"],
       "additionalProperties": false
     },
     "paastandVaretekt": {
       "type": "object",
       "description": "Påtale sier hvilke restriksjoner/isolasjonskrav som de ønsker og hvor lenge i varetekt er med dersom det er begjæring om varetekt. Gydlig fra settes dersom det begjæres om varetekt frem i tid.",
-      "required": [
-        "restriksjoner",
-        "isolasjon"
-      ],
+      "required": ["restriksjoner", "isolasjon", "begjaeringInfo"],
       "additionalProperties": false,
       "properties": {
         "begjaeringInfo": {
@@ -148,9 +137,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "dato"
-          ],
+          "required": ["dato"],
           "additionalProperties": false
         },
         "varsleBistandsadvokat": {
@@ -180,39 +167,44 @@
     "begrenseOffentlighetKrav": {
       "type": "string",
       "description": "Liste over ulike begrense offentlighet krav.",
-      "enum": [
-        "LUKKEDE_DOERER",
-        "FORBUD_GJENGIVELSE",
-        "HEMMELIGHOLD"
-      ]
+      "enum": ["LUKKEDE_DOERER", "FORBUD_GJENGIVELSE", "HEMMELIGHOLD"]
     },
     "begjaeringInfo": {
       "type": "object",
       "description": "Informasjon om hvilken type begjæring dette er og fengsling er med dersom typen begjæring er førstegangsfengsling eller forlengelse",
       "properties": {
         "begjaeringType": {
-          "$ref": "#/definitions/begjaeringType"
+          "type": "string",
+          "description": "Liste over ulike typer begjæringer.",
+          "enum": ["FOERSTEGANGS", "FORLENGELSE", "RESTRIKSJONS_ENDRING"]
         },
         "fengsling": {
           "$ref": "#/definitions/fengsling"
-        },
-        "required": ["begjaeringType"],
-        "if": {
-          "properties": {
-            "begjaeringType": { "enum": ["FOERSTEGANGS", "FORLENGELSE"] }
-          },
-          "required": ["fengsling"]
+        }
+      },
+      "required": ["begjaeringType"],
+      "dependencies": {
+        "begjaeringType": {
+          "oneOf": [
+            {
+              "properties": {
+                "begjaeringType": { "enum": ["FOERSTEGANGS", "FORLENGELSE"] },
+                "fengsling": {
+                  "$ref": "#/definitions/fengsling"
+                }
+              },
+              "required": ["fengsling"],
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "begjaeringType": { "enum": ["RESTRIKSJONS_ENDRING"] }
+              },
+              "additionalProperties": false
+            }
+          ]
         }
       }
-    },
-    "begjaeringType": {
-      "type": "string",
-      "description": "Liste over ulike typer begjæringer.",
-      "enum": [
-        "FOERSTEGANGS",
-        "FORLENGELSE",
-        "RESTRIKSJONS_ENDRING"
-      ]
     },
     "fengsling": {
       "type": "object",
@@ -222,9 +214,7 @@
           "$ref": "#/definitions/varighet"
         }
       },
-      "required": [
-        "varighet"
-      ],
+      "required": ["varighet"],
       "additionalProperties": false
     },
     "varighet": {
@@ -246,9 +236,7 @@
               "type": "integer"
             }
           },
-          "required": [
-            "antallDager"
-          ],
+          "required": ["antallDager"],
           "additionalProperties": false
         },
         {
@@ -258,9 +246,7 @@
               "const": true
             }
           },
-          "required": [
-            "tilHovedforhandling"
-          ],
+          "required": ["tilHovedforhandling"],
           "additionalProperties": false
         }
       ]
@@ -284,9 +270,7 @@
               "type": "integer"
             }
           },
-          "required": [
-            "startDag"
-          ],
+          "required": ["startDag"],
           "additionalProperties": false
         },
         {
@@ -296,9 +280,7 @@
               "format": "date"
             }
           },
-          "required": [
-            "startDato"
-          ],
+          "required": ["startDato"],
           "additionalProperties": false
         }
       ]
@@ -336,9 +318,7 @@
               "$ref": "#/definitions/spraakkodeType"
             }
           },
-          "required": [
-            "behov"
-          ],
+          "required": ["behov"],
           "additionalProperties": false
         },
         "forsvarerinformasjon": {
@@ -352,10 +332,7 @@
           }
         }
       },
-      "required": [
-        "person",
-        "verger"
-      ],
+      "required": ["person", "verger"],
       "additionalProperties": false
     },
     "spraakkodeType": {
@@ -366,10 +343,7 @@
     "behovForTolkType": {
       "type": "string",
       "description": "Er det behov for tolk",
-      "enum": [
-        "JA_POLITIET_STILLER",
-        "JA_DOMSTOLEN_STILLER"
-      ]
+      "enum": ["JA_POLITIET_STILLER", "JA_DOMSTOLEN_STILLER"]
     },
     "forsvarerinformasjon": {
       "type": "object",
@@ -386,10 +360,7 @@
               "type": "boolean"
             }
           },
-          "required": [
-            "person",
-            "erVarsletOmFenglingsmoete"
-          ],
+          "required": ["person", "erVarsletOmFenglingsmoete"],
           "additionalProperties": false
         },
         "oensketForsvarer": {
@@ -400,9 +371,7 @@
               "$ref": "#/definitions/profesjonellPerson"
             }
           },
-          "required": [
-            "person"
-          ],
+          "required": ["person"],
           "additionalProperties": false
         }
       },
@@ -427,20 +396,13 @@
           "description": "Vilkårene listet enkeltvis. Disse er sammenstilt i lovbudStreng"
         }
       },
-      "required": [
-        "lovbud",
-        "paastandVaretekt",
-        "vilkaar"
-      ],
+      "required": ["lovbud", "paastandVaretekt", "vilkaar"],
       "additionalProperties": false
     },
     "varetektsType": {
       "type": "string",
       "description": "Vanlig, eller brudd på vilkår",
-      "enum": [
-        "VANLIG",
-        "VILKAARSBRUDD"
-      ]
+      "enum": ["VANLIG", "VILKAARSBRUDD"]
     },
     "vilkaarsType": {
       "type": "string",

--- a/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
@@ -202,7 +202,7 @@
               },
               "additionalProperties": false
             }
-          ] 
+          ]
         }
       }
     },

--- a/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
@@ -108,7 +108,7 @@
         },
         "forlengelse": {
           "$ref": "#/definitions/forlengelseInfo",
-          "description": "Hvis det er en forlengelse så er dette elementet med"
+          "description": "Hvis det er en forlengelse eller en begjæring om kun restriksjoner så er dette elementet med"
         },
         "hovedforhandlingsdato": {
           "type": "string",
@@ -210,9 +210,43 @@
         }
       ]
     },
+    "periodeStart": {
+      "type": "object",
+      "description": "Periode start på restriksjon/isolasjon, start dag ved begjæring om varetekt eller start dato ved begjæring om kun restriksjoner",
+      "properties": {
+        "startDag": {
+          "type": "integer"
+        },
+        "startDato": {
+          "type": "string",
+          "format": "date"
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "startDag": {
+              "type": "integer"
+            }
+          },
+          "required": ["startDag"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "startDato": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          "required": ["startDato"],
+          "additionalProperties": false
+        }
+      ]
+    },
     "forlengelseInfo": {
       "type": "object",
-      "description": "Hvis det er en forlengelse så referer vi til forrige avgjørelse og legger ved dato for når gjeldende fengsling utløper",
+      "description": "Hvis det er en forlengelse eller begjæring om restriksjoner så referer vi til forrige avgjørelse og legger ved dato for når gjeldende fengsling utløper",
       "properties": {
         "avgjoerelseId": {
           "type": "string",
@@ -220,7 +254,7 @@
         },
         "beskrivelse": {
           "type": "string",
-          "description": "Kanskje referanse til dokument etc"
+          "description": "Kanskje referanse til dokument etc, ved begjæring av kun restriksjoner/isolasjon flagges dette her"
         },
         "fengslingUtloeperDato": {
           "type": "string",
@@ -628,12 +662,12 @@
     },
     "periodeStartVarighet": {
       "type": "object",
-      "description": "Periode for isolasjon eller restriksjon, bruker ikke å spesifisere startdato, derfor lengde og antall dager inn i fengslingen for restriksjoner",
-      "required": ["startDag", "varighet"],
+      "description": "Periode for isolasjon eller restriksjon, bruker ikke å spesifisere startdato, derfor lengde og antall dager inn i fengslingen for restriksjoner. Ved begjæring om kun restriksjon eller isolasjon spesifiseres startDato.",
+      "required": ["periodeStart", "varighet"],
       "additionalProperties": false,
       "properties": {
-        "startDag": {
-          "type": "integer"
+        "periodeStart": {
+          "$ref": "#/definitions/periodeStart"
         },
         "varighet": {
           "$ref": "#/definitions/varighet"

--- a/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
@@ -78,8 +78,8 @@
     },
     "paastandVaretekt": {
       "type": "object",
-      "description": "Påtale sier hvor hvor lenge i varetekt og hvilke restriksjoner/isolasjonskrav som de ønsker",
-      "required": ["fengsling", "restriksjoner", "isolasjon"],
+      "description": "Påtale sier hvilke restriksjoner/isolasjonskrav som de ønsker og hvor lenge i varetekt er med dersom det er begjæring om varetekt",
+      "required": ["restriksjoner", "isolasjon"],
       "additionalProperties": false,
       "properties": {
         "fengsling": {

--- a/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
@@ -49,7 +49,12 @@
           "$ref": "#/definitions/saksinformasjon"
         }
       },
-      "required": ["kravId", "siktet", "varetekt", "saksinformasjon"],
+      "required": [
+        "kravId",
+        "siktet",
+        "varetekt",
+        "saksinformasjon"
+      ],
       "additionalProperties": false
     },
     "vedlegg": {
@@ -73,21 +78,27 @@
           }
         }
       },
-      "required": ["straffesaker", "dokumenter"],
+      "required": [
+        "straffesaker",
+        "dokumenter"
+      ],
       "additionalProperties": false
     },
     "paastandVaretekt": {
       "type": "object",
       "description": "Påtale sier hvilke restriksjoner/isolasjonskrav som de ønsker og hvor lenge i varetekt er med dersom det er begjæring om varetekt. Gydlig fra settes dersom det begjæres om varetekt frem i tid.",
-      "required": ["restriksjoner", "isolasjon"],
+      "required": [
+        "restriksjoner",
+        "isolasjon"
+      ],
       "additionalProperties": false,
       "properties": {
+        "begjaeringInfo": {
+          "$ref": "#/definitions/begjaeringInfo"
+        },
         "gyldigFraDato": {
           "type": "string",
           "format": "date"
-        },
-        "fengsling": {
-          "$ref": "#/definitions/fengsling"
         },
         "restriksjoner": {
           "type": "array",
@@ -110,9 +121,9 @@
         "varetektsType": {
           "$ref": "#/definitions/varetektsType"
         },
-        "forlengelse": {
-          "$ref": "#/definitions/forlengelseInfo",
-          "description": "Hvis det er en forlengelse eller en begjæring om kun restriksjoner så er dette elementet med"
+        "aktivFengsling": {
+          "$ref": "#/definitions/aktivFengslingInfo",
+          "description": "Hvis det eksisterer en aktiv fengsling så er dette elementet med"
         },
         "hovedforhandlingsdato": {
           "type": "string",
@@ -137,7 +148,9 @@
               "type": "string"
             }
           },
-          "required": ["dato"],
+          "required": [
+            "dato"
+          ],
           "additionalProperties": false
         },
         "varsleBistandsadvokat": {
@@ -167,7 +180,39 @@
     "begrenseOffentlighetKrav": {
       "type": "string",
       "description": "Liste over ulike begrense offentlighet krav.",
-      "enum": ["LUKKEDE_DOERER", "FORBUD_GJENGIVELSE", "HEMMELIGHOLD"]
+      "enum": [
+        "LUKKEDE_DOERER",
+        "FORBUD_GJENGIVELSE",
+        "HEMMELIGHOLD"
+      ]
+    },
+    "begjaeringInfo": {
+      "type": "object",
+      "description": "Informasjon om hvilken type begjæring dette er og fengsling er med dersom typen begjæring er førstegangsfengsling eller forlengelse",
+      "properties": {
+        "begjaeringType": {
+          "$ref": "#/definitions/begjaeringType"
+        },
+        "fengsling": {
+          "$ref": "#/definitions/fengsling"
+        },
+        "required": ["begjaeringType"],
+        "if": {
+          "properties": {
+            "begjaeringType": { "enum": ["FOERSTEGANGS", "FORLENGELSE"] }
+          },
+          "required": ["fengsling"]
+        }
+      }
+    },
+    "begjaeringType": {
+      "type": "string",
+      "description": "Liste over ulike typer begjæringer.",
+      "enum": [
+        "FOERSTEGANGS",
+        "FORLENGELSE",
+        "RESTRIKSJONS_ENDRING"
+      ]
     },
     "fengsling": {
       "type": "object",
@@ -177,7 +222,9 @@
           "$ref": "#/definitions/varighet"
         }
       },
-      "required": ["varighet"],
+      "required": [
+        "varighet"
+      ],
       "additionalProperties": false
     },
     "varighet": {
@@ -199,7 +246,9 @@
               "type": "integer"
             }
           },
-          "required": ["antallDager"],
+          "required": [
+            "antallDager"
+          ],
           "additionalProperties": false
         },
         {
@@ -209,7 +258,9 @@
               "const": true
             }
           },
-          "required": ["tilHovedforhandling"],
+          "required": [
+            "tilHovedforhandling"
+          ],
           "additionalProperties": false
         }
       ]
@@ -233,7 +284,9 @@
               "type": "integer"
             }
           },
-          "required": ["startDag"],
+          "required": [
+            "startDag"
+          ],
           "additionalProperties": false
         },
         {
@@ -243,22 +296,20 @@
               "format": "date"
             }
           },
-          "required": ["startDato"],
+          "required": [
+            "startDato"
+          ],
           "additionalProperties": false
         }
       ]
     },
-    "forlengelseInfo": {
+    "aktivFengslingInfo": {
       "type": "object",
-      "description": "Hvis det er en forlengelse eller begjæring om restriksjoner så referer vi til forrige avgjørelse og legger ved dato for når gjeldende fengsling utløper",
+      "description": "Hvis det eksisterer en aktiv fengsling så refereres det til avgjørelsen for den aktive fengslingen og legges ved dato for når gjeldende fengsling utløper",
       "properties": {
         "avgjoerelseId": {
           "type": "string",
           "description": "Domstolene sin nøkkel til den forrige fengslingskjennelsen"
-        },
-        "beskrivelse": {
-          "type": "string",
-          "description": "Kanskje referanse til dokument etc, ved begjæring av kun restriksjoner/isolasjon flagges dette her"
         },
         "fengslingUtloeperDato": {
           "type": "string",
@@ -266,7 +317,6 @@
           "description": "Dato for når gjeldene/forrige fengsling utløper"
         }
       },
-      "required": ["beskrivelse"],
       "additionalProperties": false
     },
     "siktetInfo": {
@@ -286,7 +336,9 @@
               "$ref": "#/definitions/spraakkodeType"
             }
           },
-          "required": ["behov"],
+          "required": [
+            "behov"
+          ],
           "additionalProperties": false
         },
         "forsvarerinformasjon": {
@@ -300,7 +352,10 @@
           }
         }
       },
-      "required": ["person", "verger"],
+      "required": [
+        "person",
+        "verger"
+      ],
       "additionalProperties": false
     },
     "spraakkodeType": {
@@ -311,7 +366,10 @@
     "behovForTolkType": {
       "type": "string",
       "description": "Er det behov for tolk",
-      "enum": ["JA_POLITIET_STILLER", "JA_DOMSTOLEN_STILLER"]
+      "enum": [
+        "JA_POLITIET_STILLER",
+        "JA_DOMSTOLEN_STILLER"
+      ]
     },
     "forsvarerinformasjon": {
       "type": "object",
@@ -328,7 +386,10 @@
               "type": "boolean"
             }
           },
-          "required": ["person", "erVarsletOmFenglingsmoete"],
+          "required": [
+            "person",
+            "erVarsletOmFenglingsmoete"
+          ],
           "additionalProperties": false
         },
         "oensketForsvarer": {
@@ -339,7 +400,9 @@
               "$ref": "#/definitions/profesjonellPerson"
             }
           },
-          "required": ["person"],
+          "required": [
+            "person"
+          ],
           "additionalProperties": false
         }
       },
@@ -364,13 +427,20 @@
           "description": "Vilkårene listet enkeltvis. Disse er sammenstilt i lovbudStreng"
         }
       },
-      "required": ["lovbud", "paastandVaretekt", "vilkaar"],
+      "required": [
+        "lovbud",
+        "paastandVaretekt",
+        "vilkaar"
+      ],
       "additionalProperties": false
     },
     "varetektsType": {
       "type": "string",
       "description": "Vanlig, eller brudd på vilkår",
-      "enum": ["VANLIG", "VILKAARSBRUDD"]
+      "enum": [
+        "VANLIG",
+        "VILKAARSBRUDD"
+      ]
     },
     "vilkaarsType": {
       "type": "string",

--- a/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
@@ -82,7 +82,7 @@
       "required": ["restriksjoner", "isolasjon"],
       "additionalProperties": false,
       "properties": {
-        "gyldigFra": {
+        "gyldigFraDato": {
           "type": "string",
           "format": "date"
         },

--- a/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
@@ -78,7 +78,7 @@
     },
     "paastandVaretekt": {
       "type": "object",
-      "description": "Påtale sier hvilke restriksjoner/isolasjonskrav som de ønsker og hvor lenge i varetekt er med dersom det er begjæring om varetekt. Gydlig fra settes dersom det begjæres om varetekt frem i tid.",
+      "description": "Påtale sier hvilke restriksjoner/isolasjonskrav som de ønsker og info om begjaeringen, type og varighet. Gydlig fra settes dersom det begjæres om varetekt frem i tid.",
       "required": ["restriksjoner", "isolasjon", "begjaeringInfo"],
       "additionalProperties": false,
       "properties": {
@@ -202,7 +202,7 @@
               },
               "additionalProperties": false
             }
-          ]
+          ] 
         }
       }
     },

--- a/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
@@ -78,10 +78,14 @@
     },
     "paastandVaretekt": {
       "type": "object",
-      "description": "Påtale sier hvilke restriksjoner/isolasjonskrav som de ønsker og hvor lenge i varetekt er med dersom det er begjæring om varetekt",
+      "description": "Påtale sier hvilke restriksjoner/isolasjonskrav som de ønsker og hvor lenge i varetekt er med dersom det er begjæring om varetekt. Gydlig fra settes dersom det begjæres om varetekt frem i tid.",
       "required": ["restriksjoner", "isolasjon"],
       "additionalProperties": false,
       "properties": {
+        "gyldigFra": {
+          "type": "string",
+          "format": "date"
+        },
         "fengsling": {
           "$ref": "#/definitions/fengsling"
         },

--- a/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
@@ -179,9 +179,7 @@
         }
       },
       "required": ["begjaeringType"],
-      "dependencies": {
-        "begjaeringType": {
-          "oneOf": [
+      "oneOf": [
             {
               "properties": {
                 "begjaeringType": { "enum": ["FOERSTEGANGS", "FORLENGELSE"] },
@@ -199,8 +197,6 @@
               "additionalProperties": false
             }
           ]
-        }
-      }
     },
     "fengsling": {
       "type": "object",

--- a/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
@@ -85,10 +85,6 @@
         "begjaeringInfo": {
           "$ref": "#/definitions/begjaeringInfo"
         },
-        "gyldigFraDato": {
-          "type": "string",
-          "format": "date"
-        },
         "restriksjoner": {
           "type": "array",
           "items": {

--- a/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/begjaeringVaretekt.schema.json
@@ -180,23 +180,23 @@
       },
       "required": ["begjaeringType"],
       "oneOf": [
-            {
-              "properties": {
-                "begjaeringType": { "enum": ["FOERSTEGANGS", "FORLENGELSE"] },
-                "fengsling": {
-                  "$ref": "#/definitions/fengsling"
-                }
-              },
-              "required": ["fengsling"],
-              "additionalProperties": false
-            },
-            {
-              "properties": {
-                "begjaeringType": { "enum": ["RESTRIKSJONS_ENDRING"] }
-              },
-              "additionalProperties": false
+        {
+          "properties": {
+            "begjaeringType": { "enum": ["FOERSTEGANGS", "FORLENGELSE"] },
+            "fengsling": {
+              "$ref": "#/definitions/fengsling"
             }
-          ]
+          },
+          "required": ["fengsling"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "begjaeringType": { "enum": ["RESTRIKSJONS_ENDRING"] }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "fengsling": {
       "type": "object",

--- a/kontrakter/politi/varetekt/arbeidsversjon/eksempelfiler/begjaeringVaretekt-eksempel-1.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/eksempelfiler/begjaeringVaretekt-eksempel-1.json
@@ -40,9 +40,7 @@
         ],
         "personAdresse": {
           "adresse": {
-            "adresselinjer": [
-              "Rugdeberget 2"
-            ],
+            "adresselinjer": ["Rugdeberget 2"],
             "postnummer": "1266",
             "poststed": "OSLO"
           }
@@ -165,9 +163,7 @@
         "sted": "Sal 3, tinghuset"
       },
       "varsleBistandsadvokat": "Retten anmodes om å varsle bistandsadvokaten om tidspunktet for rettsmøtet, jf. straffeprosessloven § 107c, 2. led",
-      "begrenseOffentlighet": [
-        "FORBUD_GJENGIVELSE"
-      ],
+      "begrenseOffentlighet": ["FORBUD_GJENGIVELSE"],
       "ansvarligPaatalejurist": {
         "brukeridentifikasjon": "BLC218",
         "fornavn": "BLC218",
@@ -189,9 +185,7 @@
             "gjerningstidspunktFra": "2022-01-01T00:00:00+02:00",
             "gjerningstidspunktTil": "2022-01-01T00:00:00+02:00",
             "gjerningssted": {
-              "adresselinjer": [
-                "Waldemar Carlsens veg 4"
-              ],
+              "adresselinjer": ["Waldemar Carlsens veg 4"],
               "postnummer": "2214",
               "poststed": "KONGSVINGER",
               "land": {
@@ -236,9 +230,7 @@
                 ],
                 "personAdresse": {
                   "adresse": {
-                    "adresselinjer": [
-                      "Bjørklund 21"
-                    ],
+                    "adresselinjer": ["Bjørklund 21"],
                     "postnummer": "4137",
                     "poststed": "ÅRDAL I RYFYLKE"
                   }
@@ -293,9 +285,7 @@
                 ],
                 "personAdresse": {
                   "adresse": {
-                    "adresselinjer": [
-                      "Bratsberggata 29"
-                    ],
+                    "adresselinjer": ["Bratsberggata 29"],
                     "postnummer": "3714",
                     "poststed": "SKIEN"
                   }
@@ -322,9 +312,7 @@
               ],
               "personAdresse": {
                 "adresse": {
-                  "adresselinjer": [
-                    "Øvstedalsvegen 87"
-                  ],
+                  "adresselinjer": ["Øvstedalsvegen 87"],
                   "postnummer": "6391",
                   "poststed": "TRESFJORD"
                 }
@@ -349,9 +337,7 @@
               ],
               "personAdresse": {
                 "adresse": {
-                  "adresselinjer": [
-                    "Geisnesvegen 1505"
-                  ],
+                  "adresselinjer": ["Geisnesvegen 1505"],
                   "postnummer": "7960",
                   "poststed": "SALSBRUKET"
                 }

--- a/kontrakter/politi/varetekt/arbeidsversjon/eksempelfiler/begjaeringVaretekt-eksempel-1.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/eksempelfiler/begjaeringVaretekt-eksempel-1.json
@@ -40,7 +40,9 @@
         ],
         "personAdresse": {
           "adresse": {
-            "adresselinjer": ["Rugdeberget 2"],
+            "adresselinjer": [
+              "Rugdeberget 2"
+            ],
             "postnummer": "1266",
             "poststed": "OSLO"
           }
@@ -90,7 +92,9 @@
               "lovbudStreng": "Strpl. § 186, 2.ledd 1.pkt."
             },
             "periode": {
-              "startDag": 1,
+              "periodeStart": {
+                "startDag": 1
+              },
               "varighet": {
                 "antallDager": 14
               }
@@ -102,7 +106,9 @@
               "lovbudStreng": "Strpl. § 186, 2.ledd 1.pkt."
             },
             "periode": {
-              "startDag": 15,
+              "periodeStart": {
+                "startDag": 15
+              },
               "varighet": {
                 "antallDager": 14
               }
@@ -116,7 +122,9 @@
               "lovbudStreng": "Strpl. § 186a"
             },
             "periode": {
-              "startDag": 1,
+              "periodeStart": {
+                "startDag": 1
+              },
               "varighet": {
                 "tilHovedforhandling": true
               }
@@ -157,7 +165,9 @@
         "sted": "Sal 3, tinghuset"
       },
       "varsleBistandsadvokat": "Retten anmodes om å varsle bistandsadvokaten om tidspunktet for rettsmøtet, jf. straffeprosessloven § 107c, 2. led",
-      "begrenseOffentlighet": ["FORBUD_GJENGIVELSE"],
+      "begrenseOffentlighet": [
+        "FORBUD_GJENGIVELSE"
+      ],
       "ansvarligPaatalejurist": {
         "brukeridentifikasjon": "BLC218",
         "fornavn": "BLC218",
@@ -179,7 +189,9 @@
             "gjerningstidspunktFra": "2022-01-01T00:00:00+02:00",
             "gjerningstidspunktTil": "2022-01-01T00:00:00+02:00",
             "gjerningssted": {
-              "adresselinjer": ["Waldemar Carlsens veg 4"],
+              "adresselinjer": [
+                "Waldemar Carlsens veg 4"
+              ],
               "postnummer": "2214",
               "poststed": "KONGSVINGER",
               "land": {
@@ -224,7 +236,9 @@
                 ],
                 "personAdresse": {
                   "adresse": {
-                    "adresselinjer": ["Bjørklund 21"],
+                    "adresselinjer": [
+                      "Bjørklund 21"
+                    ],
                     "postnummer": "4137",
                     "poststed": "ÅRDAL I RYFYLKE"
                   }
@@ -279,7 +293,9 @@
                 ],
                 "personAdresse": {
                   "adresse": {
-                    "adresselinjer": ["Bratsberggata 29"],
+                    "adresselinjer": [
+                      "Bratsberggata 29"
+                    ],
                     "postnummer": "3714",
                     "poststed": "SKIEN"
                   }
@@ -306,7 +322,9 @@
               ],
               "personAdresse": {
                 "adresse": {
-                  "adresselinjer": ["Øvstedalsvegen 87"],
+                  "adresselinjer": [
+                    "Øvstedalsvegen 87"
+                  ],
                   "postnummer": "6391",
                   "poststed": "TRESFJORD"
                 }
@@ -331,7 +349,9 @@
               ],
               "personAdresse": {
                 "adresse": {
-                  "adresselinjer": ["Geisnesvegen 1505"],
+                  "adresselinjer": [
+                    "Geisnesvegen 1505"
+                  ],
                   "postnummer": "7960",
                   "poststed": "SALSBRUKET"
                 }

--- a/kontrakter/politi/varetekt/arbeidsversjon/eksempelfiler/begjaeringVaretekt-eksempel-2.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/eksempelfiler/begjaeringVaretekt-eksempel-2.json
@@ -90,7 +90,9 @@
               "lovbudStreng": "Strpl. § 186, 2.ledd 1.pkt."
             },
             "periode": {
-              "startDag": 1,
+              "periodeStart": {
+                "startDato": "2023-04-01"
+              },
               "varighet": {
                 "antallDager": 14
               }
@@ -102,7 +104,9 @@
               "lovbudStreng": "Strpl. § 186, 2.ledd 1.pkt."
             },
             "periode": {
-              "startDag": 15,
+              "periodeStart": {
+                "startDato": "2023-04-01"
+              },
               "varighet": {
                 "antallDager": 14
               }
@@ -116,7 +120,9 @@
               "lovbudStreng": "Strpl. § 186a"
             },
             "periode": {
-              "startDag": 1,
+              "periodeStart": {
+                "startDato": "2023-04-01"
+              },
               "varighet": {
                 "antallDager": 14
               }
@@ -148,7 +154,9 @@
     "saksinformasjon": {
       "varetektsType": "VANLIG",
       "forlengelse": {
-        "beskrivelse": "forlengelse"
+        "avgjoerelseId": "avgjoerleseID_1",
+        "beskrivelse": "Begjæring om restriksjoner",
+        "fengslingUtloeperDato": "2023-04-19"
       },
       "paagrepetTidspunkt": "2023-02-28T17:21:27+02:00",
       "berammetFengslingsmoete": {

--- a/kontrakter/politi/varetekt/arbeidsversjon/eksempelfiler/begjaeringVaretekt-eksempel-2.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/eksempelfiler/begjaeringVaretekt-eksempel-2.json
@@ -78,11 +78,6 @@
         "lovbudStreng": "Straffeprosessloven § 171 første ledd nr. 2 og 3, jf. §§ 170a og 185"
       },
       "paastandVaretekt": {
-        "fengsling": {
-          "varighet": {
-            "antallDager": 28
-          }
-        },
         "restriksjoner": [
           {
             "restriksjonsType": "BREV_OG_BESOEKSFORBUD",

--- a/kontrakter/politi/varetekt/arbeidsversjon/eksempelfiler/begjaeringVaretekt-eksempel-2.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/eksempelfiler/begjaeringVaretekt-eksempel-2.json
@@ -78,6 +78,14 @@
         "lovbudStreng": "Straffeprosessloven § 171 første ledd nr. 2 og 3, jf. §§ 170a og 185"
       },
       "paastandVaretekt": {
+        "begjaeringInfo": {
+          "begjaeringType": "FORLENGELSE",
+          "fengsling": {
+            "varighet": {
+              "tilHovedforhandling": true
+            }
+          }
+        },
         "restriksjoner": [
           {
             "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
@@ -148,9 +156,8 @@
     },
     "saksinformasjon": {
       "varetektsType": "VANLIG",
-      "forlengelse": {
+      "aktivFengsling": {
         "avgjoerelseId": "avgjoerleseID_1",
-        "beskrivelse": "Begjæring om restriksjoner",
         "fengslingUtloeperDato": "2023-04-19"
       },
       "paagrepetTidspunkt": "2023-02-28T17:21:27+02:00",

--- a/kontrakter/politi/varetekt/arbeidsversjon/eksempelfiler/begjaeringVaretekt-eksempel-3.json
+++ b/kontrakter/politi/varetekt/arbeidsversjon/eksempelfiler/begjaeringVaretekt-eksempel-3.json
@@ -79,12 +79,7 @@
       },
       "paastandVaretekt": {
         "begjaeringInfo": {
-          "begjaeringType": "FOERSTEGANGS",
-          "fengsling": {
-            "varighet": {
-              "tilHovedforhandling": true
-            }
-          }
+          "begjaeringType": "RESTRIKSJONS_ENDRING"
         },
         "restriksjoner": [
           {
@@ -94,7 +89,7 @@
             },
             "periode": {
               "periodeStart": {
-                "startDag": 1
+                "startDato": "2023-04-01"
               },
               "varighet": {
                 "antallDager": 14
@@ -108,7 +103,7 @@
             },
             "periode": {
               "periodeStart": {
-                "startDag": 15
+                "startDato": "2023-04-01"
               },
               "varighet": {
                 "antallDager": 14
@@ -124,10 +119,10 @@
             },
             "periode": {
               "periodeStart": {
-                "startDag": 1
+                "startDato": "2023-04-01"
               },
               "varighet": {
-                "tilHovedforhandling": true
+                "antallDager": 14
               }
             }
           }
@@ -156,7 +151,10 @@
     },
     "saksinformasjon": {
       "varetektsType": "VANLIG",
-      "hovedforhandlingsdato": "2023-12-11",
+      "aktivFengsling": {
+        "avgjoerelseId": "avgjoerleseID_1",
+        "fengslingUtloeperDato": "2023-04-19"
+      },
       "paagrepetTidspunkt": "2023-02-28T17:21:27+02:00",
       "berammetFengslingsmoete": {
         "dato": "2023-04-19",

--- a/kontrakter/politi/varetekt/changelog.md
+++ b/kontrakter/politi/varetekt/changelog.md
@@ -7,6 +7,17 @@
 | 1.1     | Tolk og til hovedforhandling              | 01.08.2023 | 09.10.2023 |
 | 1.0     | Brukertest juni 2023, ikke til produksjon |            | 01.08.2023 |
 
+## Versjon 1.4
+
+### Begjæring om kun restriksjoner
+
+Ved forlengelse eller skjerping av restriksjoner i en gjeldene varetektsfengsling skal det kunne begjæres om kun restriksjoner. 
+Det er lagt til periodeStart bestående av startDag og startDato, hvor startDato for restriksjoner/isolasjon settes for å kunne si når de skal gjelde/forlenges fra. 
+
+### Begjæring om varetekt gyldig fra 
+
+Dersom det begjæres om varetekt frem i tid er det lagt til et felt gyldigFraDato i paastandVaretekt som sier når begjæringen er gyldig fra.
+
 ## Versjon 1.3
 
 ### Fødselsdato på vitner er optional

--- a/kontrakter/politi/varetekt/changelog.md
+++ b/kontrakter/politi/varetekt/changelog.md
@@ -7,15 +7,11 @@
 | 1.1     | Tolk og til hovedforhandling              | 01.08.2023 | 09.10.2023 |
 | 1.0     | Brukertest juni 2023, ikke til produksjon |            | 01.08.2023 |
 
-## Versjon 1.4
+## Versjon 1.X TODO: oppdatere til riktig versjon ved merge
 
 ### Begjæring info 
 
 Lagt til begjæring info objekt som inneholder typen begjæring (enum verdi: FOERSTEGANGS, FORLENGELSE, RESTRIKSJONS_ENDRING) og fengslingsobjekt med varighet er påkrevd dersom typen er førstegangsfengsling eller forlengelse. Dersom det er en begjæring om kun restriksjoner (RESTRIKSJONS_ENDRING) er fengslingsobjektet ikke med og det er lagt til periodeStart bestående av startDag og startDato, hvor startDato for restriksjoner/isolasjon settes for å kunne si når de skal gjelde/forlenges fra. 
-
-### Begjæring om varetekt gyldig fra 
-
-Dersom det begjæres om varetekt frem i tid er det lagt til et felt gyldigFraDato i paastandVaretekt som sier når begjæringen er gyldig fra.
 
 ## Versjon 1.3
 

--- a/kontrakter/politi/varetekt/changelog.md
+++ b/kontrakter/politi/varetekt/changelog.md
@@ -9,10 +9,9 @@
 
 ## Versjon 1.4
 
-### Begjæring om kun restriksjoner
+### Begjæring info 
 
-Ved forlengelse eller skjerping av restriksjoner i en gjeldene varetektsfengsling skal det kunne begjæres om kun restriksjoner. 
-Det er lagt til periodeStart bestående av startDag og startDato, hvor startDato for restriksjoner/isolasjon settes for å kunne si når de skal gjelde/forlenges fra. 
+Lagt til begjæring info objekt som inneholder typen begjæring (enum verdi: FOERSTEGANGS, FORLENGELSE, RESTRIKSJONS_ENDRING) og fengslingsobjekt med varighet er påkrevd dersom typen er førstegangsfengsling eller forlengelse. Dersom det er en begjæring om kun restriksjoner (RESTRIKSJONS_ENDRING) er fengslingsobjektet ikke med og det er lagt til periodeStart bestående av startDag og startDato, hvor startDato for restriksjoner/isolasjon settes for å kunne si når de skal gjelde/forlenges fra. 
 
 ### Begjæring om varetekt gyldig fra 
 


### PR DESCRIPTION
Forslag til hvordan vi kan få inn begjæring av kun restriksjoner/isolasjon i samme skjema som begjæring av varetekt. For begjæring av kun restriksjoner/isolasjon vil det kunne sendes med startDato for når reststriksjonen/isolasjonen skal gjelde fra. Begjæringen vil også kobles mot forrige kjennelse/avgjørelse ved å bruke forlengelse objektet hvor avgjørelseId fylles ut samt en beskrivelse av at dette er en begjæring om restriksjoner og når gjeldende fengsling utløper. 