### PR TITLE
Utvide LoeslatelseFraFengselAarsakType med 3 nye verdier

### DIFF
--- a/kontrakter-xsd/kriminalomsorg/straffegjennomfoering/Felles/1.0/Felles.xsd
+++ b/kontrakter-xsd/kriminalomsorg/straffegjennomfoering/Felles/1.0/Felles.xsd
@@ -202,6 +202,9 @@
       <xs:enumeration value="Utvist fra Norge"/>
       <xs:enumeration value="Utlevert til utlandet etter begjæring"/>
       <xs:enumeration value="Løslatt etter 7/12 tid"/>
+      <xs:enumeration value="Løslatt endt tid og utvist (soning)"/>
+      <xs:enumeration value="Prøveløslatt strgjfl. § 42.1 og utvist (soning) (prøveløslatelse 2/3-tid)"/>
+      <xs:enumeration value="Prøveløslatt strgjfl. § 42.4 og utvist (soning) (kort tid før endt tid)"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="EndringOppdaterteDatoerAarsakType">


### PR DESCRIPTION
1: Kategori UB - Restdager = 0 - Årsak:  Løslatt endt tid og utvist (soning)
2: Kategori UB - Restdager = mer enn 10 dager - Årsak: Prøveløslatt strgjfl. § 42.1 og utvist (soning) (prøveløslatelse 2/3-tid)
3: Kategori UB - Restdager mellom 1-10 dager - Årsak: Prøveløslatt strgjfl. § 42.4 og utvist (soning) (kort tid før endt tid)

Eksisterende årsakstypen (Årsak: Utvist fra Norge) er nå begrenset til Kategori V