### PR TITLE
Nærmere beskrivelse av at til-dato nå betyr til-og-med eller "ikke-utover-denne-dato".

### DIFF
--- a/kontrakter/politi/kjennelsevaretektpoliti/arbeidsversjon/kjennelseVaretektPoliti.schema.json
+++ b/kontrakter/politi/kjennelsevaretektpoliti/arbeidsversjon/kjennelseVaretektPoliti.schema.json
@@ -1,752 +1,1008 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://politiet.no/politi/kjennelseVaretektPoliti/arbeidsversjon/kjennelseVaretektPoliti",
-  "description": "Kjennelse fra domstolen førtegangsfengsling eller forlengelser.",
-  "type": "object",
-  "properties": {
-    "forsendelse": {
-      "$ref": "#/definitions/forsendelse",
-      "description": "avsender og mottaker"
-    },
-    "hovedStraffesaksnummer": {
-      "$ref": "#/definitions/straffesaksnummer",
-      "description": "BL Saksbehandlersak er hovedsaken i et sakskompleks (som er 1 eller flere straffesaker)"
-    },
-    "varetektSyklusId": {
-      "$ref": "#/definitions/unikId",
-      "description": "En syklus fra pågripelse til løslatelse, vil ikke være med til å begynne med"
-    },
-    "personVaretektInfo": {
-      "$ref": "#/definitions/personVaretektInfo"
-    },
-    "kjennelseVaretekt": {
-      "$ref": "#/definitions/kjennelseVaretekt"
-    },
-    "paagrepetSted": {
-      "type": "string",
-      "description": "Sted for pågripelse. Vil være satt i ca 20% av tilfellene"
-    },
-    "paagrepetTidspunkt": { "$ref": "#/definitions/datoTid" },
-    "dokumenter": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/dokument"
-      }
-    }
-  },
-  "required": [
-    "forsendelse",
-    "hovedStraffesaksnummer",
-    "personVaretektInfo",
-    "kjennelseVaretekt",
-    "dokumenter"
-  ],
-  "additionalProperties": false,
-  "definitions": {
-    "adresse": {
-      "type": "object",
-      "properties": {
-        "adresselinjer": {
-          "type": "array",
-          "contains": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 500
-          },
-          "minContains": 1,
-          "maxContains": 4
-        },
-        "postnummer": { "type": "string" },
-        "poststed": { "type": "string" },
-        "land": { "$ref": "#/definitions/land" }
-      },
-      "required": ["adresselinjer"],
-      "additionalProperties": false
-    },
-    "adresseGradering": {
-      "description": "Samme enum som folkeregisteret, ugradert hvis den ikke er gradert",
-      "type": "string",
-      "enum": ["KLIENT_ADRESSE", "FORTROLIG", "STRENGT_FORTROLIG"]
-    },
-    "personVaretektInfo": {
-      "type": "object",
-      "description": "Data om personen og straffesaker personen er involvert i",
-      "properties": {
-        "personVaretekt": {
-          "$ref": "#/definitions/person",
-          "description": "Straffesak personen, forskjeller ser du ved å sammenligne med data fra domstolen"
-        },
-        "straffesaker": {
-          "type": "array",
-          "title": "straffesaker",
-          "items": { "$ref": "#/definitions/straffesakInvolverte" },
-          "minItems": 1
-        }
-      },
-      "required": ["personVaretekt", "straffesaker"],
-      "additionalProperties": false
-    },
-
-    "anke": {
-      "description": "Anke av fengsling/restriksjon/kjennelse",
-      "properties": {
-        "anketDato": { "$ref": "#/definitions/dato" },
-        "oppsettendeVirkning": { "type": "boolean" }
-      },
-      "type": "object",
-      "required": ["anketDato"],
-      "additionalProperties": false
-    },
-    "ansattPerson": {
-      "type": "object",
-      "description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
-      "properties": {
-        "tittel": { "type": "string" },
-        "fornavn": { "type": "string" },
-        "mellomnavn": { "type": "string" },
-        "etternavn": { "type": "string" },
-        "kontakt": {
-          "$ref": "#/definitions/kontaktInfo",
-          "description": "Er ikke med i første fase, burde inneholde kontaktinformasjon på forsendelsen."
-        }
-      },
-      "required": ["etternavn"],
-      "additionalProperties": false
-    },
-    "avsender": {
-      "type": "object",
-      "properties": {
-        "organisasjon": { "$ref": "#/definitions/organisasjon" },
-        "person": {
-          "$ref": "#/definitions/ansattPerson",
-          "description": "Person som trykker på send til domstolen."
-        }
-      },
-      "required": ["organisasjon"],
-      "additionalProperties": false
-    },
-    "dokument": {
-      "type": "object",
-      "description": "Dokument som oversendes på justishub",
-      "properties": {
-        "internId": { "type": "string" },
-        "kategori": { "$ref": "#/definitions/kodeverk" },
-        "overskrift": { "type": "string" },
-        "skrevetDato": { "$ref": "#/definitions/dato" },
-        "forsendelse": { "$ref": "#/definitions/dokumentForsendelse" }
-      },
-      "required": ["overskrift", "forsendelse"],
-      "additionalProperties": false
-    },
-    "dokumentForsendelse": {
-      "type": "object",
-      "description": "Detaljer om lokasjon og type",
-      "properties": {
-        "mimeType": { "type": "string" },
-        "uri": { "type": "string" },
-        "sjekksum": { "type": "string" }
-      },
-      "required": ["mimeType", "uri", "sjekksum"],
-      "additionalProperties": false
-    },
-    "forsendelse": {
-      "type": "object",
-      "properties": {
-        "meldingsId": { "type": "string" },
-        "sendtTid": { "$ref": "#/definitions/datoTid" },
-        "avsender": { "$ref": "#/definitions/avsender" },
-        "mottakerOrganisasjon": {
-          "$ref": "#/definitions/organisasjon",
-          "description": "Kriminalomsorg som skal være mottaker"
-        }
-      },
-      "required": [
-        "meldingsId",
-        "avsender",
-        "mottakerOrganisasjon",
-        "sendtTid"
-      ],
-      "additionalProperties": false
-    },
-    "fengsling": {
-      "description": "Fengsling som en del av kjennelsen, uten datoer så er det ikke noe fengsel nå.",
-      "properties": {
-        "fengslingsId": {
-          "type": "string",
-          "description": "fengslingsid som opprettes i DA (GUID)"
-        },
-        "fraDato": { "$ref": "#/definitions/dato" },
-        "tilDato": { "$ref": "#/definitions/dato" },
-        "fengslingsFristDato": { "$ref": "#/definitions/dato" },
-        "lovbud": { "$ref": "#/definitions/lovbudEnkel" },
-        "merknad": {
-          "type": "string",
-          "description": "Merknad til fengslingen"
-        }
-      },
-      "required": ["fengslingsId"],
-      "type": "object",
-      "additionalProperties": false
-    },
-    "foretak": {
-      "description": "Foretak/ organisasjon som er med i en straffesak som f.eks. fornærmet",
-      "type": "object",
-      "properties": {
-        "internId": { "type": "string" },
-        "organisasjonsnummer": { "$ref": "#/definitions/organisasjonsnummer" },
-        "navn": { "type": "string" },
-        "adresse": { "$ref": "#/definitions/adresse" }
-      },
-      "required": ["internId", "navn"],
-      "additionalProperties": false
-    },
-    "isolasjon": {
-      "description": "Isolasjon fra domstolen, når vi har mottatt den, uten til fra dato kun når det er anke",
-      "properties": {
-        "isolasjonsId": {
-          "type": "string",
-          "description": "isolasjonsId som opprettes i DA (GUID)"
-        },
-        "isolasjonsType": {
-          "$ref": "#/definitions/isolasjonsType"
-        },
-        "fraDato": {
-          "$ref": "#/definitions/dato",
-          "description": "Om begjæringen ikke tas til følge skal dette feltet settes til null."
-        },
-        "tilDato": {
-          "$ref": "#/definitions/dato",
-          "description": "Om begjæringen ikke tas til følge skal dette feltet settes til null."
-        }
-      },
-      "required": ["isolasjonsId", "isolasjonsType"],
-      "type": "object",
-      "additionalProperties": false
-    },
-    "isolasjonsType": {
-      "description": "Liste over de ulike isolasjonstyper",
-      "enum": ["FULL", "DELVIS", "INGEN"],
-      "type": "string"
-    },
-    "involverteStraffesak": {
-      "type": "object",
-      "description": "siktede, vitner og fornærmede",
-      "properties": {
-        "siktet": { "$ref": "#/definitions/personEnkel" },
-        "medsiktede": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/personForetak" }
-        },
-        "fornaermede": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/personForetak" }
-        },
-        "vitner": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/personVitne" }
-        }
-      },
-      "required": ["medsiktede", "fornaermede", "vitner"],
-      "additionalProperties": false
-    },
-    "kodeverk": {
-      "type": "object",
-      "properties": {
-        "kode": { "type": "string" },
-        "navn": { "type": "string" }
-      },
-      "required": ["kode"],
-      "additionalProperties": false
-    },
-    "kontaktInfo": {
-      "type": "object",
-      "properties": {
-        "epost": { "type": "string" },
-        "telefonnummer": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/telefonnummer" }
-        }
-      },
-      "required": ["telefonnummer"],
-      "additionalProperties": false
-    },
-    "kjennelseVaretekt": {
-      "description": "Kjennelse på varetektsfengsling fra domstolen som sendes videre til Kriminalomsorgen",
-      "type": "object",
-      "properties": {
-        "domstol": { "$ref": "#/definitions/organisasjon" },
-        "domstolsaktoerer": { "$ref": "#/definitions/domstolsaktoerer" },
-        "avgjoerelseId": {
-          "type": "string",
-          "description": "Domstolen sin nøkkel til avgjørelsen. Kan bli brukt i forbindelse med anke/forlengelse"
-        },
-        "kjennelseSendtTid": {
-          "$ref": "#/definitions/datoTid",
-          "description": "Tidspunktet kjennelsen ble sendt fra domstolen"
-        },
-        "avsagtDato": { "$ref": "#/definitions/dato" },
-        "kravid": {
-          "type": "string",
-          "description": "Kravid som opprettes i politiet (begjæring om varetektsfengsling)"
-        },
-        "personVaretektDomstol": {
-          "$ref": "#/definitions/person",
-          "description": "Persondata fra domstolene, kan være forskjellig fra politiet sine data"
-        },
-        "forlengelse": {
-          "type": "boolean",
-          "description": "Forlengelse = true også hvis det er en endring i restriksjoner fra domstolene"
-        },
-        "fengsling": {
-          "$ref": "#/definitions/fengsling",
-          "description": "Førstegangsfengslinger vil alltid inneholde fengsling, men senere kan det komme med kun restriksjoner, isolasjon."
-        },
-        "restriksjoner": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/restriksjon" },
-          "minItems": 1
-        },
-        "isolasjonsKrav": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/isolasjon" },
-          "minItems": 1
-        },
-        "anke": {
-          "$ref": "#/definitions/anke",
-          "description": "Settes kun dersom hele eller deler av avgjørelsen ankes før kjennelsen sendes til påtale"
-        }
-      },
-      "required": [
-        "domstol",
-        "domstolsaktoerer",
-        "avgjoerelseId",
-        "kjennelseSendtTid",
-        "avsagtDato",
-        "personVaretektDomstol",
-        "kravid",
-        "forlengelse",
-        "restriksjoner",
-        "isolasjonsKrav"
-      ],
-      "additionalProperties": false
-    },
-    "kjoenn": {
-      "description": "Samme enum som folkeregisteret",
-      "type": "string",
-      "enum": ["KVINNE", "MANN"]
-    },
-    "personFregIdentifikator": {
-      "type": "object",
-      "description": "Fødselsnummer eller D-nummer. I bruk på de som aldri vil ha SSP nummer",
-      "properties": {
-        "foedselsnummer": {
-          "$ref": "#/definitions/foedselsnummer"
-        },
-        "dNummer": {
-          "$ref": "#/definitions/dNummer"
-        }
-      },
-      "oneOf": [
-        {
-          "properties": {
-            "foedselsnummer": {
-              "$ref": "#/definitions/foedselsnummer"
-            }
-          },
-          "required": ["foedselsnummer"],
-          "additionalProperties": false
-        },
-        {
-          "properties": {
-            "dNummer": {
-              "$ref": "#/definitions/dNummer"
-            }
-          },
-          "required": ["dNummer"],
-          "additionalProperties": false
-        }
-      ]
-    },
-    "personIdentifikator": {
-      "description": "Fødselsnummer, D-nummer eller SSP nummer.",
-      "type": "object",
-      "properties": {
-        "foedselsnummer": { "$ref": "#/definitions/foedselsnummer" },
-        "sspNummer": { "$ref": "#/definitions/sspNummer" },
-        "dNummer": { "$ref": "#/definitions/dNummer" }
-      },
-      "oneOf": [
-        {
-          "properties": {
-            "foedselsnummer": { "$ref": "#/definitions/foedselsnummer" }
-          },
-          "required": ["foedselsnummer"],
-          "additionalProperties": false
-        },
-        {
-          "properties": {
-            "sspNummer": { "$ref": "#/definitions/sspNummer" }
-          },
-          "required": ["sspNummer"],
-          "additionalProperties": false
-        },
-        {
-          "properties": {
-            "dNummer": { "$ref": "#/definitions/dNummer" }
-          },
-          "required": ["dNummer"],
-          "additionalProperties": false
-        }
-      ]
-    },
-    "lovbudEnkel": {
-      "type": "object",
-      "description": "Enkel lovbudreferanse kun lovbudstreng",
-      "properties": {
-        "lovbudId": { "type": "string" },
-        "lovbudStreng": { "type": "string" }
-      },
-      "required": ["lovbudStreng"],
-      "additionalProperties": false
-    },
-    "organisasjon": {
-      "type": "object",
-      "description": "Entydig identifikator av juridisk enhet. F.eks en spesifik domstol eller kriminalomsorg",
-      "properties": {
-        "navn": {
-          "type": "string",
-          "description": "F.eks. Oslo politidistikt, Riksadvokaten, Borgarting lagmannsrett"
-        },
-        "organisasjonsnummer": { "$ref": "#/definitions/organisasjonsnummer" }
-      },
-      "required": ["organisasjonsnummer", "navn"],
-      "additionalProperties": false
-    },
-    "personnavn": {
-      "type": "object",
-      "properties": {
-        "fornavn": { "type": "string" },
-        "mellomnavn": { "type": "string" },
-        "etternavn": { "type": "string" }
-      },
-      "required": ["etternavn"],
-      "additionalProperties": false
-    },
-    "personForetak": {
-      "description": "En siktet eller fornærmet kan være en person eller et foretak, denne typen er enten person eller foretak.",
-      "type": "object",
-      "properties": {
-        "person": { "$ref": "#/definitions/person" },
-        "foretak": { "$ref": "#/definitions/foretak" }
-      },
-      "oneOf": [
-        {
-          "properties": {
-            "person": { "$ref": "#/definitions/person" }
-          },
-          "additionalProperties": false,
-          "required": ["person"]
-        },
-        {
-          "properties": {
-            "foretak": { "$ref": "#/definitions/foretak" }
-          },
-          "additionalProperties": false,
-          "required": ["foretak"]
-        }
-      ]
-    },
-    "personAdresse": {
-      "description": "Kan være graderte adresser",
-      "type": "object",
-      "properties": {
-        "gradering": { "$ref": "#/definitions/adresseGradering" },
-        "adresse": { "$ref": "#/definitions/adresse" }
-      },
-      "required": ["adresse"],
-      "additionalProperties": false
-    },
-    "personVitne": {
-      "type": "object",
-      "description": "Personer som er involverte, men ikke siktet. Kan være verger, vitner, etc.",
-      "properties": {
-        "internId": {
-          "type": "string",
-          "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId"
-        },
-        "navn": {
-          "$ref": "#/definitions/personnavn"
-        },
-        "foedselsdato": {
-          "type": "string",
-          "format": "date"
-        },
-        "kjoenn": {
-          "$ref": "#/definitions/kjoenn",
-          "description": "Ukjent kjønn hvis denne ikke er med"
-        },
-        "statsborgerskap": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/land"
-          }
-        },
-        "identitetsnummer": {
-          "$ref": "#/definitions/personFregIdentifikator",
-          "description": "Fødselsnummer eller D-nummer. Vitner og verger skal aldri ha SSP nummer"
-        },
-        "adresseGradering": {
-          "$ref": "#/definitions/adresseGradering",
-          "description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå"
-        },
-        "personAdresse": {
-          "$ref": "#/definitions/personAdresse"
-        }
-      },
-      "required": ["internId", "navn", "statsborgerskap"],
-      "additionalProperties": false
-    },
-    "person": {
-      "type": "object",
-      "description": "Person med alle nyttige data som fødselsnummer adresse osv., SSP nummer kun på siktede, tiltalte.",
-      "properties": {
-        "internId": {
-          "type": "string",
-          "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId"
-        },
-        "navn": { "$ref": "#/definitions/personnavn" },
-        "foedselsdato": { "$ref": "#/definitions/dato" },
-        "kjoenn": {
-          "$ref": "#/definitions/kjoenn",
-          "description": "Ukjent kjønn hvis denne ikke er med"
-        },
-        "statsborgerskap": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/land" }
-        },
-        "identitetsnummer": {
-          "$ref": "#/definitions/personIdentifikator",
-          "description": "Fødselsnummer, D-nummer eller SSP nummer som er i bruk. Siktede vil alltid ha med denne."
-        },
-        "tilleggsId": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/personIdentifikator" },
-          "description": "Kan være SSP nummer hvis person har D-nummer, fremtidig historiske nummer?"
-        },
-        "adresseGradering": {
-          "$ref": "#/definitions/adresseGradering",
-          "description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå"
-        },
-        "personAdresse": {
-          "$ref": "#/definitions/personAdresse"
-        },
-        "verger": {
-          "type": "array",
-          "description": "Verge skal være med på siktet, fornærmet, vitne.",
-          "items": { "$ref": "#/definitions/personRelatert" }
-        }
-      },
-      "required": [
-        "internId",
-        "navn",
-        "statsborgerskap",
-        "tilleggsId",
-        "verger"
-      ],
-      "additionalProperties": false
-    },
-    "personEnkel": {
-      "type": "object",
-      "description": "Kun navn og fødselsdato (hvis den finnes)",
-      "properties": {
-        "internId": {
-          "type": "string",
-          "description": "Intern som peker på samme person i en spesifikk melding"
-        },
-        "navn": { "$ref": "#/definitions/personnavn" },
-        "foedselsdato": { "$ref": "#/definitions/dato" }
-      },
-      "required": ["internId", "navn"],
-      "additionalProperties": false
-    },
-    "personRelatert": {
-      "type": "object",
-      "description": "Personer relatert til straffesaken som verger og advokater",
-      "properties": {
-        "internId": {
-          "type": "string",
-          "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId, en verge kan f.eks. også være vitne i saken"
-        },
-        "tittel": { "type": "string" },
-        "navn": { "$ref": "#/definitions/personnavn" },
-        "foedselsdato": {
-          "$ref": "#/definitions/dato",
-          "description": "På de vi har det, sjekke om vi kan dele"
-        },
-        "kjoenn": {
-          "$ref": "#/definitions/kjoenn",
-          "description": "Ukjent kjønn hvis denne ikke er med"
-        },
-        "foedselsnummer": {
-          "$ref": "#/definitions/foedselsnummer",
-          "description": "Fødselsnummer f.eks på verger. Vil ikke være utfylt på advokater."
-        }
-      },
-      "required": ["internId", "navn"],
-      "additionalProperties": false
-    },
-    "restriksjon": {
-      "description": "Restriksjon fra domstolen, når vi har mottatt den, uten til fra dato kun når det er anke",
-      "type": "object",
-      "properties": {
-        "restriksjonsId": {
-          "type": "string",
-          "description": "restriksjonsId som opprettes i DA (GUID)"
-        },
-        "restriksjonsType": { "$ref": "#/definitions/restriksjonsType" },
-        "fraDato": {
-          "description": "Om begjæringen ikke tas til følge er dette feltet satt til null.",
-          "$ref": "#/definitions/dato"
-        },
-        "tilDato": {
-          "description": "Om begjæringen ikke tas til følge er dette feltet satt til null.",
-          "$ref": "#/definitions/dato"
-        }
-      },
-      "required": ["restriksjonsId", "restriksjonsType"],
-      "additionalProperties": false
-    },
-    "restriksjonsType": {
-      "description": "Liste over de ulike restriksjonene",
-      "type": "string",
-      "enum": [
-        "BREV_OG_BESOEKSFORBUD",
-        "BREV_OG_BESOEKSKONTROLL",
-        "MEDIEFORBUD",
-        "INGEN"
-      ]
-    },
-    "straffesakInvolverte": {
-      "type": "object",
-      "description": "Straffesak med statistikkgrupper, krimtype og de involverte",
-      "properties": {
-        "straffesaksnummer": { "$ref": "#/definitions/straffesaksnummer" },
-        "detaljer": { "$ref": "#/definitions/straffesakDetaljer" },
-        "involverte": { "$ref": "#/definitions/involverteStraffesak" }
-      },
-      "required": ["straffesaksnummer", "detaljer", "involverte"],
-      "additionalProperties": false
-    },
-    "domstolsaktoerer": {
-      "type": "object",
-      "description": "Aktører fra domstolen",
-      "properties": {
-        "dommer": {
-          "$ref": "#/definitions/ansattPerson",
-          "description": "Dommer på saken"
-        },
-        "saksbehandler": {
-          "$ref": "#/definitions/ansattPerson",
-          "description": "Saksbehandler på saken"
-        }
-      },
-      "required": ["dommer"],
-      "additionalProperties": false
-    },
-    "straffesakDetaljer": {
-      "type": "object",
-      "description": "Detaljer rundt straffesaken, OBS krimType er ikke klart ennå-.s",
-      "properties": {
-        "hendelse": { "$ref": "#/definitions/hendelse" },
-        "statistikkgruppe": { "$ref": "#/definitions/kodeverk" },
-        "krimtype": { "$ref": "#/definitions/kodeverk" }
-      },
-      "required": ["hendelse", "statistikkgruppe"],
-      "additionalProperties": false
-    },
-    "hendelse": {
-      "type": "object",
-      "description": "Tid og sted for den straffbare handlingen",
-      "properties": {
-        "gjerningstidspunktFra": { "$ref": "#/definitions/datoTid" },
-        "gjerningstidspunktTil": { "$ref": "#/definitions/datoTid" },
-        "gjerningssted": { "$ref": "#/definitions/adresse" }
-      },
-      "required": [
-        "gjerningstidspunktFra",
-        "gjerningstidspunktTil",
-        "gjerningssted"
-      ],
-      "additionalProperties": false
-    },
-    "land": {
-      "type": "object",
-      "description": "ISO-3166, Kosovo kommer",
-      "properties": {
-        "kode": {
-          "type": "string",
-          "pattern": "^[A-Z]+$",
-          "minLength": 3,
-          "maxLength": 3
-        },
-        "navn": { "type": "string" }
-      },
-      "required": ["kode"],
-      "additionalProperties": false
-    },
-    "straffesaksnummer": {
-      "type": "string",
-      "description": "Som regel et løpenummer, men kan i fremtiden også inneholde bokstaver",
-      "minLength": 3,
-      "maxLength": 30
-    },
-    "telefonnummer": {
-      "type": "string",
-      "description": "Ett telefonnummer, norsk eller utenlands, med eller uten land prefix",
-      "maxLength": 30,
-      "minLength": 1
-    },
-    "foedselsnummer": {
-      "type": "string",
-      "description": "Se skatteetaten. Kan være vanlig med 6 sifret fødselsdato og fiktivt (Tenor) fødselsnummer med +80 på måned slik at noen født 10.01.1990 begynner fiktivt nummer med 108190",
-      "pattern": "^[0-3][0-9][0189][0-9]+$",
-      "minLength": 11,
-      "maxLength": 11
-    },
-    "sspNummer": {
-      "type": "string",
-      "description": "Personidentifikator brukt av det sentrale straffe- og personopplysningsregisteret (SSP) hvis personen ikke har fødselsnummer. Validerer som et fødselsnummer med +20 på måned så noen født 10.01.1990 begynner med 102190",
-      "pattern": "^[0-3][0-9][2-3][0-9]+$",
-      "minLength": 11,
-      "maxLength": 11
-    },
-    "dNummer": {
-      "type": "string",
-      "description": "Se skatteetaten. Dag på datodelen er +40. Født 10.01.1990, begynner med 51.01.90. Fiktivt (Tenor) dNummer vil har +80 på måned som for Tenor fødselsnummer",
-      "pattern": "^[4-7][0-9][0189][0-9]+$",
-      "minLength": 11,
-      "maxLength": 11
-    },
-    "organisasjonsnummer": {
-      "type": "string",
-      "description": "Norsk organisasjonsnummer fra BRREG. Referanse til politistrikt, domstol, fengsel. https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/organisasjonsnummeret/",
-      "pattern": "^[0-9]+$",
-      "minLength": 9,
-      "maxLength": 9
-    },
-    "unikId": {
-      "type": "string",
-      "description": "GUID eller andre unike id'er. Trenger ikke være global unik.",
-      "maxLength": 40,
-      "minLength": 1
-    },
-    "datoTid": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "dato": {
-      "type": "string",
-      "format": "date"
-    }
-  }
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://politiet.no/politi/kjennelseVaretektPoliti/arbeidsversjon/kjennelseVaretektPoliti",
+	"description": "Kjennelse fra domstolen førtegangsfengsling eller forlengelser.",
+	"type": "object",
+	"properties": {
+		"forsendelse": {
+			"description": "avsender og mottaker",
+			"$ref": "#/definitions/forsendelse"
+		},
+		"hovedStraffesaksnummer": {
+			"description": "BL Saksbehandlersak er hovedsaken i et sakskompleks (som er 1 eller flere straffesaker)",
+			"$ref": "#/definitions/straffesaksnummer"
+		},
+		"varetektSyklusId": {
+			"description": "En syklus fra pågripelse til løslatelse, vil ikke være med til å begynne med",
+			"$ref": "#/definitions/unikId"
+		},
+		"personVaretektInfo": {
+			"$ref": "#/definitions/personVaretektInfo"
+		},
+		"kjennelseVaretekt": {
+			"$ref": "#/definitions/kjennelseVaretekt"
+		},
+		"paagrepetSted": {
+			"description": "Sted for pågripelse. Vil være satt i ca 20% av tilfellene",
+			"type": "string"
+		},
+		"paagrepetTidspunkt": {
+			"$ref": "#/definitions/datoTid"
+		},
+		"dokumenter": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/dokument"
+			}
+		}
+	},
+	"required": [
+		"forsendelse",
+		"hovedStraffesaksnummer",
+		"personVaretektInfo",
+		"kjennelseVaretekt",
+		"dokumenter"
+	],
+	"additionalProperties": false,
+	"definitions": {
+		"adresse": {
+			"type": "object",
+			"properties": {
+				"adresselinjer": {
+					"type": "array",
+					"contains": {
+						"type": "string",
+						"minLength": 1,
+						"maxLength": 500
+					},
+					"minContains": 1,
+					"maxContains": 4
+				},
+				"postnummer": {
+					"type": "string"
+				},
+				"poststed": {
+					"type": "string"
+				},
+				"land": {
+					"$ref": "#/definitions/land"
+				}
+			},
+			"required": [
+				"adresselinjer"
+			],
+			"additionalProperties": false
+		},
+		"adresseGradering": {
+			"description": "Samme enum som folkeregisteret, ugradert hvis den ikke er gradert",
+			"type": "string",
+			"enum": [
+				"KLIENT_ADRESSE",
+				"FORTROLIG",
+				"STRENGT_FORTROLIG"
+			]
+		},
+		"personVaretektInfo": {
+			"description": "Data om personen og straffesaker personen er involvert i",
+			"type": "object",
+			"properties": {
+				"personVaretekt": {
+					"description": "Straffesak personen, forskjeller ser du ved å sammenligne med data fra domstolen",
+					"$ref": "#/definitions/person"
+				},
+				"straffesaker": {
+					"title": "straffesaker",
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/straffesakInvolverte"
+					}
+				}
+			},
+			"required": [
+				"personVaretekt",
+				"straffesaker"
+			],
+			"additionalProperties": false
+		},
+		"anke": {
+			"description": "Anke av fengsling/restriksjon/kjennelse",
+			"type": "object",
+			"properties": {
+				"anketDato": {
+					"$ref": "#/definitions/dato"
+				},
+				"oppsettendeVirkning": {
+					"type": "boolean"
+				}
+			},
+			"required": [
+				"anketDato"
+			],
+			"additionalProperties": false
+		},
+		"ansattPerson": {
+			"description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
+			"type": "object",
+			"properties": {
+				"tittel": {
+					"type": "string"
+				},
+				"fornavn": {
+					"type": "string"
+				},
+				"mellomnavn": {
+					"type": "string"
+				},
+				"etternavn": {
+					"type": "string"
+				},
+				"kontakt": {
+					"description": "Er ikke med i første fase, burde inneholde kontaktinformasjon på forsendelsen.",
+					"$ref": "#/definitions/kontaktInfo"
+				}
+			},
+			"required": [
+				"etternavn"
+			],
+			"additionalProperties": false
+		},
+		"avsender": {
+			"type": "object",
+			"properties": {
+				"organisasjon": {
+					"$ref": "#/definitions/organisasjon"
+				},
+				"person": {
+					"description": "Person som trykker på send til domstolen.",
+					"$ref": "#/definitions/ansattPerson"
+				}
+			},
+			"required": [
+				"organisasjon"
+			],
+			"additionalProperties": false
+		},
+		"dokument": {
+			"description": "Dokument som oversendes på justishub",
+			"type": "object",
+			"properties": {
+				"internId": {
+					"type": "string"
+				},
+				"kategori": {
+					"$ref": "#/definitions/kodeverk"
+				},
+				"overskrift": {
+					"type": "string"
+				},
+				"skrevetDato": {
+					"$ref": "#/definitions/dato"
+				},
+				"forsendelse": {
+					"$ref": "#/definitions/dokumentForsendelse"
+				}
+			},
+			"required": [
+				"overskrift",
+				"forsendelse"
+			],
+			"additionalProperties": false
+		},
+		"dokumentForsendelse": {
+			"description": "Detaljer om lokasjon og type",
+			"type": "object",
+			"properties": {
+				"mimeType": {
+					"type": "string"
+				},
+				"uri": {
+					"type": "string"
+				},
+				"sjekksum": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"mimeType",
+				"uri",
+				"sjekksum"
+			],
+			"additionalProperties": false
+		},
+		"forsendelse": {
+			"type": "object",
+			"properties": {
+				"meldingsId": {
+					"type": "string"
+				},
+				"sendtTid": {
+					"$ref": "#/definitions/datoTid"
+				},
+				"avsender": {
+					"$ref": "#/definitions/avsender"
+				},
+				"mottakerOrganisasjon": {
+					"description": "Kriminalomsorg som skal være mottaker",
+					"$ref": "#/definitions/organisasjon"
+				}
+			},
+			"required": [
+				"meldingsId",
+				"sendtTid",
+				"avsender",
+				"mottakerOrganisasjon"
+			],
+			"additionalProperties": false
+		},
+		"fengsling": {
+			"description": "Fengsling som en del av kjennelsen, uten datoer så er det ikke noe fengsel nå.",
+			"type": "object",
+			"properties": {
+				"fengslingsId": {
+					"description": "fengslingsid som opprettes i DA (GUID)",
+					"type": "string"
+				},
+				"fraDato": {
+					"$ref": "#/definitions/dato"
+				},
+				"tilDato": {
+					"description": "Ikke utover gitt til-dato. Dvs til-og-med.",
+					"$ref": "#/definitions/dato"
+				},
+				"fengslingsFristDato": {
+					"$ref": "#/definitions/dato"
+				},
+				"lovbud": {
+					"$ref": "#/definitions/lovbudEnkel"
+				},
+				"merknad": {
+					"description": "Merknad til fengslingen",
+					"type": "string"
+				}
+			},
+			"required": [
+				"fengslingsId"
+			],
+			"additionalProperties": false
+		},
+		"foretak": {
+			"description": "Foretak/ organisasjon som er med i en straffesak som f.eks. fornærmet",
+			"type": "object",
+			"properties": {
+				"internId": {
+					"type": "string"
+				},
+				"organisasjonsnummer": {
+					"$ref": "#/definitions/organisasjonsnummer"
+				},
+				"navn": {
+					"type": "string"
+				},
+				"adresse": {
+					"$ref": "#/definitions/adresse"
+				}
+			},
+			"required": [
+				"internId",
+				"navn"
+			],
+			"additionalProperties": false
+		},
+		"isolasjon": {
+			"description": "Isolasjon fra domstolen, når vi har mottatt den, uten til fra dato kun når det er anke",
+			"type": "object",
+			"properties": {
+				"isolasjonsId": {
+					"description": "isolasjonsId som opprettes i DA (GUID)",
+					"type": "string"
+				},
+				"isolasjonsType": {
+					"$ref": "#/definitions/isolasjonsType"
+				},
+				"fraDato": {
+					"description": "Om begjæringen ikke tas til følge skal dette feltet settes til null.",
+					"$ref": "#/definitions/dato"
+				},
+				"tilDato": {
+					"description": "Om begjæringen ikke tas til følge skal dette feltet settes til null. Ikke utover gitt til-dato. Dvs til-og-med.",
+					"$ref": "#/definitions/dato"
+				}
+			},
+			"required": [
+				"isolasjonsId",
+				"isolasjonsType"
+			],
+			"additionalProperties": false
+		},
+		"isolasjonsType": {
+			"description": "Liste over de ulike isolasjonstyper",
+			"type": "string",
+			"enum": [
+				"FULL",
+				"DELVIS",
+				"INGEN"
+			]
+		},
+		"involverteStraffesak": {
+			"description": "siktede, vitner og fornærmede",
+			"type": "object",
+			"properties": {
+				"siktet": {
+					"$ref": "#/definitions/personEnkel"
+				},
+				"medsiktede": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/personForetak"
+					}
+				},
+				"fornaermede": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/personForetak"
+					}
+				},
+				"vitner": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/personVitne"
+					}
+				}
+			},
+			"required": [
+				"medsiktede",
+				"fornaermede",
+				"vitner"
+			],
+			"additionalProperties": false
+		},
+		"kodeverk": {
+			"type": "object",
+			"properties": {
+				"kode": {
+					"type": "string"
+				},
+				"navn": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"kode"
+			],
+			"additionalProperties": false
+		},
+		"kontaktInfo": {
+			"type": "object",
+			"properties": {
+				"epost": {
+					"type": "string"
+				},
+				"telefonnummer": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/telefonnummer"
+					}
+				}
+			},
+			"required": [
+				"telefonnummer"
+			],
+			"additionalProperties": false
+		},
+		"kjennelseVaretekt": {
+			"description": "Kjennelse på varetektsfengsling fra domstolen som sendes videre til Kriminalomsorgen",
+			"type": "object",
+			"properties": {
+				"domstol": {
+					"$ref": "#/definitions/organisasjon"
+				},
+				"domstolsaktoerer": {
+					"$ref": "#/definitions/domstolsaktoerer"
+				},
+				"avgjoerelseId": {
+					"description": "Domstolen sin nøkkel til avgjørelsen. Kan bli brukt i forbindelse med anke/forlengelse",
+					"type": "string"
+				},
+				"kjennelseSendtTid": {
+					"description": "Tidspunktet kjennelsen ble sendt fra domstolen",
+					"$ref": "#/definitions/datoTid"
+				},
+				"avsagtDato": {
+					"$ref": "#/definitions/dato"
+				},
+				"kravid": {
+					"description": "Kravid som opprettes i politiet (begjæring om varetektsfengsling)",
+					"type": "string"
+				},
+				"personVaretektDomstol": {
+					"description": "Persondata fra domstolene, kan være forskjellig fra politiet sine data",
+					"$ref": "#/definitions/person"
+				},
+				"forlengelse": {
+					"description": "Forlengelse = true også hvis det er en endring i restriksjoner fra domstolene",
+					"type": "boolean"
+				},
+				"fengsling": {
+					"description": "Førstegangsfengslinger vil alltid inneholde fengsling, men senere kan det komme med kun restriksjoner, isolasjon.",
+					"$ref": "#/definitions/fengsling"
+				},
+				"restriksjoner": {
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/restriksjon"
+					}
+				},
+				"isolasjonsKrav": {
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/isolasjon"
+					}
+				},
+				"anke": {
+					"description": "Settes kun dersom hele eller deler av avgjørelsen ankes før kjennelsen sendes til påtale",
+					"$ref": "#/definitions/anke"
+				}
+			},
+			"required": [
+				"domstol",
+				"domstolsaktoerer",
+				"avgjoerelseId",
+				"kjennelseSendtTid",
+				"avsagtDato",
+				"kravid",
+				"personVaretektDomstol",
+				"forlengelse",
+				"restriksjoner",
+				"isolasjonsKrav"
+			],
+			"additionalProperties": false
+		},
+		"kjoenn": {
+			"description": "Samme enum som folkeregisteret",
+			"type": "string",
+			"enum": [
+				"KVINNE",
+				"MANN"
+			]
+		},
+		"personFregIdentifikator": {
+			"description": "Fødselsnummer eller D-nummer. I bruk på de som aldri vil ha SSP nummer",
+			"type": "object",
+			"properties": {
+				"foedselsnummer": {
+					"$ref": "#/definitions/foedselsnummer"
+				},
+				"dNummer": {
+					"$ref": "#/definitions/dNummer"
+				}
+			},
+			"oneOf": [
+				{
+					"properties": {
+						"foedselsnummer": {
+							"$ref": "#/definitions/foedselsnummer"
+						}
+					},
+					"required": [
+						"foedselsnummer"
+					],
+					"additionalProperties": false
+				},
+				{
+					"properties": {
+						"dNummer": {
+							"$ref": "#/definitions/dNummer"
+						}
+					},
+					"required": [
+						"dNummer"
+					],
+					"additionalProperties": false
+				}
+			]
+		},
+		"personIdentifikator": {
+			"description": "Fødselsnummer, D-nummer eller SSP nummer.",
+			"type": "object",
+			"properties": {
+				"foedselsnummer": {
+					"$ref": "#/definitions/foedselsnummer"
+				},
+				"sspNummer": {
+					"$ref": "#/definitions/sspNummer"
+				},
+				"dNummer": {
+					"$ref": "#/definitions/dNummer"
+				}
+			},
+			"oneOf": [
+				{
+					"properties": {
+						"foedselsnummer": {
+							"$ref": "#/definitions/foedselsnummer"
+						}
+					},
+					"required": [
+						"foedselsnummer"
+					],
+					"additionalProperties": false
+				},
+				{
+					"properties": {
+						"sspNummer": {
+							"$ref": "#/definitions/sspNummer"
+						}
+					},
+					"required": [
+						"sspNummer"
+					],
+					"additionalProperties": false
+				},
+				{
+					"properties": {
+						"dNummer": {
+							"$ref": "#/definitions/dNummer"
+						}
+					},
+					"required": [
+						"dNummer"
+					],
+					"additionalProperties": false
+				}
+			]
+		},
+		"lovbudEnkel": {
+			"description": "Enkel lovbudreferanse kun lovbudstreng",
+			"type": "object",
+			"properties": {
+				"lovbudId": {
+					"type": "string"
+				},
+				"lovbudStreng": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"lovbudStreng"
+			],
+			"additionalProperties": false
+		},
+		"organisasjon": {
+			"description": "Entydig identifikator av juridisk enhet. F.eks en spesifik domstol eller kriminalomsorg",
+			"type": "object",
+			"properties": {
+				"navn": {
+					"description": "F.eks. Oslo politidistikt, Riksadvokaten, Borgarting lagmannsrett",
+					"type": "string"
+				},
+				"organisasjonsnummer": {
+					"$ref": "#/definitions/organisasjonsnummer"
+				}
+			},
+			"required": [
+				"navn",
+				"organisasjonsnummer"
+			],
+			"additionalProperties": false
+		},
+		"personnavn": {
+			"type": "object",
+			"properties": {
+				"fornavn": {
+					"type": "string"
+				},
+				"mellomnavn": {
+					"type": "string"
+				},
+				"etternavn": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"etternavn"
+			],
+			"additionalProperties": false
+		},
+		"personForetak": {
+			"description": "En siktet eller fornærmet kan være en person eller et foretak, denne typen er enten person eller foretak.",
+			"type": "object",
+			"properties": {
+				"person": {
+					"$ref": "#/definitions/person"
+				},
+				"foretak": {
+					"$ref": "#/definitions/foretak"
+				}
+			},
+			"oneOf": [
+				{
+					"properties": {
+						"person": {
+							"$ref": "#/definitions/person"
+						}
+					},
+					"required": [
+						"person"
+					],
+					"additionalProperties": false
+				},
+				{
+					"properties": {
+						"foretak": {
+							"$ref": "#/definitions/foretak"
+						}
+					},
+					"required": [
+						"foretak"
+					],
+					"additionalProperties": false
+				}
+			]
+		},
+		"personAdresse": {
+			"description": "Kan være graderte adresser",
+			"type": "object",
+			"properties": {
+				"gradering": {
+					"$ref": "#/definitions/adresseGradering"
+				},
+				"adresse": {
+					"$ref": "#/definitions/adresse"
+				}
+			},
+			"required": [
+				"adresse"
+			],
+			"additionalProperties": false
+		},
+		"personVitne": {
+			"description": "Personer som er involverte, men ikke siktet. Kan være verger, vitner, etc.",
+			"type": "object",
+			"properties": {
+				"internId": {
+					"description": "Intern id i melding, samme person i denne meldingen vil ha samme internId",
+					"type": "string"
+				},
+				"navn": {
+					"$ref": "#/definitions/personnavn"
+				},
+				"foedselsdato": {
+					"type": "string",
+					"format": "date"
+				},
+				"kjoenn": {
+					"description": "Ukjent kjønn hvis denne ikke er med",
+					"$ref": "#/definitions/kjoenn"
+				},
+				"statsborgerskap": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/land"
+					}
+				},
+				"identitetsnummer": {
+					"description": "Fødselsnummer eller D-nummer. Vitner og verger skal aldri ha SSP nummer",
+					"$ref": "#/definitions/personFregIdentifikator"
+				},
+				"adresseGradering": {
+					"description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå",
+					"$ref": "#/definitions/adresseGradering"
+				},
+				"personAdresse": {
+					"$ref": "#/definitions/personAdresse"
+				}
+			},
+			"required": [
+				"internId",
+				"navn",
+				"statsborgerskap"
+			],
+			"additionalProperties": false
+		},
+		"person": {
+			"description": "Person med alle nyttige data som fødselsnummer adresse osv., SSP nummer kun på siktede, tiltalte.",
+			"type": "object",
+			"properties": {
+				"internId": {
+					"description": "Intern id i melding, samme person i denne meldingen vil ha samme internId",
+					"type": "string"
+				},
+				"navn": {
+					"$ref": "#/definitions/personnavn"
+				},
+				"foedselsdato": {
+					"$ref": "#/definitions/dato"
+				},
+				"kjoenn": {
+					"description": "Ukjent kjønn hvis denne ikke er med",
+					"$ref": "#/definitions/kjoenn"
+				},
+				"statsborgerskap": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/land"
+					}
+				},
+				"identitetsnummer": {
+					"description": "Fødselsnummer, D-nummer eller SSP nummer som er i bruk. Siktede vil alltid ha med denne.",
+					"$ref": "#/definitions/personIdentifikator"
+				},
+				"tilleggsId": {
+					"description": "Kan være SSP nummer hvis person har D-nummer, fremtidig historiske nummer?",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/personIdentifikator"
+					}
+				},
+				"adresseGradering": {
+					"description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå",
+					"$ref": "#/definitions/adresseGradering"
+				},
+				"personAdresse": {
+					"$ref": "#/definitions/personAdresse"
+				},
+				"verger": {
+					"description": "Verge skal være med på siktet, fornærmet, vitne.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/personRelatert"
+					}
+				}
+			},
+			"required": [
+				"internId",
+				"navn",
+				"statsborgerskap",
+				"tilleggsId",
+				"verger"
+			],
+			"additionalProperties": false
+		},
+		"personEnkel": {
+			"description": "Kun navn og fødselsdato (hvis den finnes)",
+			"type": "object",
+			"properties": {
+				"internId": {
+					"description": "Intern som peker på samme person i en spesifikk melding",
+					"type": "string"
+				},
+				"navn": {
+					"$ref": "#/definitions/personnavn"
+				},
+				"foedselsdato": {
+					"$ref": "#/definitions/dato"
+				}
+			},
+			"required": [
+				"internId",
+				"navn"
+			],
+			"additionalProperties": false
+		},
+		"personRelatert": {
+			"description": "Personer relatert til straffesaken som verger og advokater",
+			"type": "object",
+			"properties": {
+				"internId": {
+					"description": "Intern id i melding, samme person i denne meldingen vil ha samme internId, en verge kan f.eks. også være vitne i saken",
+					"type": "string"
+				},
+				"tittel": {
+					"type": "string"
+				},
+				"navn": {
+					"$ref": "#/definitions/personnavn"
+				},
+				"foedselsdato": {
+					"description": "På de vi har det, sjekke om vi kan dele",
+					"$ref": "#/definitions/dato"
+				},
+				"kjoenn": {
+					"description": "Ukjent kjønn hvis denne ikke er med",
+					"$ref": "#/definitions/kjoenn"
+				},
+				"foedselsnummer": {
+					"description": "Fødselsnummer f.eks på verger. Vil ikke være utfylt på advokater.",
+					"$ref": "#/definitions/foedselsnummer"
+				}
+			},
+			"required": [
+				"internId",
+				"navn"
+			],
+			"additionalProperties": false
+		},
+		"restriksjon": {
+			"description": "Restriksjon fra domstolen, når vi har mottatt den, uten til fra dato kun når det er anke",
+			"type": "object",
+			"properties": {
+				"restriksjonsId": {
+					"description": "restriksjonsId som opprettes i DA (GUID)",
+					"type": "string"
+				},
+				"restriksjonsType": {
+					"$ref": "#/definitions/restriksjonsType"
+				},
+				"fraDato": {
+					"description": "Om begjæringen ikke tas til følge er dette feltet satt til null.",
+					"$ref": "#/definitions/dato"
+				},
+				"tilDato": {
+					"description": "Om begjæringen ikke tas til følge er dette feltet satt til null. Ikke utover gitt til-dato. Dvs til-og-med.",
+					"$ref": "#/definitions/dato"
+				}
+			},
+			"required": [
+				"restriksjonsId",
+				"restriksjonsType"
+			],
+			"additionalProperties": false
+		},
+		"restriksjonsType": {
+			"description": "Liste over de ulike restriksjonene",
+			"type": "string",
+			"enum": [
+				"BREV_OG_BESOEKSFORBUD",
+				"BREV_OG_BESOEKSKONTROLL",
+				"MEDIEFORBUD",
+				"INGEN"
+			]
+		},
+		"straffesakInvolverte": {
+			"description": "Straffesak med statistikkgrupper, krimtype og de involverte",
+			"type": "object",
+			"properties": {
+				"straffesaksnummer": {
+					"$ref": "#/definitions/straffesaksnummer"
+				},
+				"detaljer": {
+					"$ref": "#/definitions/straffesakDetaljer"
+				},
+				"involverte": {
+					"$ref": "#/definitions/involverteStraffesak"
+				}
+			},
+			"required": [
+				"straffesaksnummer",
+				"detaljer",
+				"involverte"
+			],
+			"additionalProperties": false
+		},
+		"domstolsaktoerer": {
+			"description": "Aktører fra domstolen",
+			"type": "object",
+			"properties": {
+				"dommer": {
+					"description": "Dommer på saken",
+					"$ref": "#/definitions/ansattPerson"
+				},
+				"saksbehandler": {
+					"description": "Saksbehandler på saken",
+					"$ref": "#/definitions/ansattPerson"
+				}
+			},
+			"required": [
+				"dommer"
+			],
+			"additionalProperties": false
+		},
+		"straffesakDetaljer": {
+			"description": "Detaljer rundt straffesaken, OBS krimType er ikke klart ennå-.s",
+			"type": "object",
+			"properties": {
+				"hendelse": {
+					"$ref": "#/definitions/hendelse"
+				},
+				"statistikkgruppe": {
+					"$ref": "#/definitions/kodeverk"
+				},
+				"krimtype": {
+					"$ref": "#/definitions/kodeverk"
+				}
+			},
+			"required": [
+				"hendelse",
+				"statistikkgruppe"
+			],
+			"additionalProperties": false
+		},
+		"hendelse": {
+			"description": "Tid og sted for den straffbare handlingen",
+			"type": "object",
+			"properties": {
+				"gjerningstidspunktFra": {
+					"$ref": "#/definitions/datoTid"
+				},
+				"gjerningstidspunktTil": {
+					"$ref": "#/definitions/datoTid"
+				},
+				"gjerningssted": {
+					"$ref": "#/definitions/adresse"
+				}
+			},
+			"required": [
+				"gjerningstidspunktFra",
+				"gjerningstidspunktTil",
+				"gjerningssted"
+			],
+			"additionalProperties": false
+		},
+		"land": {
+			"description": "ISO-3166, Kosovo kommer",
+			"type": "object",
+			"properties": {
+				"kode": {
+					"type": "string",
+					"minLength": 3,
+					"maxLength": 3,
+					"pattern": "^[A-Z]+$"
+				},
+				"navn": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"kode"
+			],
+			"additionalProperties": false
+		},
+		"straffesaksnummer": {
+			"description": "Som regel et løpenummer, men kan i fremtiden også inneholde bokstaver",
+			"type": "string",
+			"minLength": 3,
+			"maxLength": 30
+		},
+		"telefonnummer": {
+			"description": "Ett telefonnummer, norsk eller utenlands, med eller uten land prefix",
+			"type": "string",
+			"minLength": 1,
+			"maxLength": 30
+		},
+		"foedselsnummer": {
+			"description": "Se skatteetaten. Kan være vanlig med 6 sifret fødselsdato og fiktivt (Tenor) fødselsnummer med +80 på måned slik at noen født 10.01.1990 begynner fiktivt nummer med 108190",
+			"type": "string",
+			"minLength": 11,
+			"maxLength": 11,
+			"pattern": "^[0-3][0-9][0189][0-9]+$"
+		},
+		"sspNummer": {
+			"description": "Personidentifikator brukt av det sentrale straffe- og personopplysningsregisteret (SSP) hvis personen ikke har fødselsnummer. Validerer som et fødselsnummer med +20 på måned så noen født 10.01.1990 begynner med 102190",
+			"type": "string",
+			"minLength": 11,
+			"maxLength": 11,
+			"pattern": "^[0-3][0-9][2-3][0-9]+$"
+		},
+		"dNummer": {
+			"description": "Se skatteetaten. Dag på datodelen er +40. Født 10.01.1990, begynner med 51.01.90. Fiktivt (Tenor) dNummer vil har +80 på måned som for Tenor fødselsnummer",
+			"type": "string",
+			"minLength": 11,
+			"maxLength": 11,
+			"pattern": "^[4-7][0-9][0189][0-9]+$"
+		},
+		"organisasjonsnummer": {
+			"description": "Norsk organisasjonsnummer fra BRREG. Referanse til politistrikt, domstol, fengsel. https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/organisasjonsnummeret/",
+			"type": "string",
+			"minLength": 9,
+			"maxLength": 9,
+			"pattern": "^[0-9]+$"
+		},
+		"unikId": {
+			"description": "GUID eller andre unike id'er. Trenger ikke være global unik.",
+			"type": "string",
+			"minLength": 1,
+			"maxLength": 40
+		},
+		"datoTid": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"dato": {
+			"type": "string",
+			"format": "date"
+		}
+	}
 }

--- a/kontrakter/politi/kjennelsevaretektpoliti/arbeidsversjon/kjennelseVaretektPoliti.schema.json
+++ b/kontrakter/politi/kjennelsevaretektpoliti/arbeidsversjon/kjennelseVaretektPoliti.schema.json
@@ -1,1008 +1,916 @@
 {
-	"$schema": "https://json-schema.org/draft/2020-12/schema",
-	"$id": "https://politiet.no/politi/kjennelseVaretektPoliti/arbeidsversjon/kjennelseVaretektPoliti",
-	"description": "Kjennelse fra domstolen førtegangsfengsling eller forlengelser.",
-	"type": "object",
-	"properties": {
-		"forsendelse": {
-			"description": "avsender og mottaker",
-			"$ref": "#/definitions/forsendelse"
-		},
-		"hovedStraffesaksnummer": {
-			"description": "BL Saksbehandlersak er hovedsaken i et sakskompleks (som er 1 eller flere straffesaker)",
-			"$ref": "#/definitions/straffesaksnummer"
-		},
-		"varetektSyklusId": {
-			"description": "En syklus fra pågripelse til løslatelse, vil ikke være med til å begynne med",
-			"$ref": "#/definitions/unikId"
-		},
-		"personVaretektInfo": {
-			"$ref": "#/definitions/personVaretektInfo"
-		},
-		"kjennelseVaretekt": {
-			"$ref": "#/definitions/kjennelseVaretekt"
-		},
-		"paagrepetSted": {
-			"description": "Sted for pågripelse. Vil være satt i ca 20% av tilfellene",
-			"type": "string"
-		},
-		"paagrepetTidspunkt": {
-			"$ref": "#/definitions/datoTid"
-		},
-		"dokumenter": {
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/dokument"
-			}
-		}
-	},
-	"required": [
-		"forsendelse",
-		"hovedStraffesaksnummer",
-		"personVaretektInfo",
-		"kjennelseVaretekt",
-		"dokumenter"
-	],
-	"additionalProperties": false,
-	"definitions": {
-		"adresse": {
-			"type": "object",
-			"properties": {
-				"adresselinjer": {
-					"type": "array",
-					"contains": {
-						"type": "string",
-						"minLength": 1,
-						"maxLength": 500
-					},
-					"minContains": 1,
-					"maxContains": 4
-				},
-				"postnummer": {
-					"type": "string"
-				},
-				"poststed": {
-					"type": "string"
-				},
-				"land": {
-					"$ref": "#/definitions/land"
-				}
-			},
-			"required": [
-				"adresselinjer"
-			],
-			"additionalProperties": false
-		},
-		"adresseGradering": {
-			"description": "Samme enum som folkeregisteret, ugradert hvis den ikke er gradert",
-			"type": "string",
-			"enum": [
-				"KLIENT_ADRESSE",
-				"FORTROLIG",
-				"STRENGT_FORTROLIG"
-			]
-		},
-		"personVaretektInfo": {
-			"description": "Data om personen og straffesaker personen er involvert i",
-			"type": "object",
-			"properties": {
-				"personVaretekt": {
-					"description": "Straffesak personen, forskjeller ser du ved å sammenligne med data fra domstolen",
-					"$ref": "#/definitions/person"
-				},
-				"straffesaker": {
-					"title": "straffesaker",
-					"type": "array",
-					"minItems": 1,
-					"items": {
-						"$ref": "#/definitions/straffesakInvolverte"
-					}
-				}
-			},
-			"required": [
-				"personVaretekt",
-				"straffesaker"
-			],
-			"additionalProperties": false
-		},
-		"anke": {
-			"description": "Anke av fengsling/restriksjon/kjennelse",
-			"type": "object",
-			"properties": {
-				"anketDato": {
-					"$ref": "#/definitions/dato"
-				},
-				"oppsettendeVirkning": {
-					"type": "boolean"
-				}
-			},
-			"required": [
-				"anketDato"
-			],
-			"additionalProperties": false
-		},
-		"ansattPerson": {
-			"description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
-			"type": "object",
-			"properties": {
-				"tittel": {
-					"type": "string"
-				},
-				"fornavn": {
-					"type": "string"
-				},
-				"mellomnavn": {
-					"type": "string"
-				},
-				"etternavn": {
-					"type": "string"
-				},
-				"kontakt": {
-					"description": "Er ikke med i første fase, burde inneholde kontaktinformasjon på forsendelsen.",
-					"$ref": "#/definitions/kontaktInfo"
-				}
-			},
-			"required": [
-				"etternavn"
-			],
-			"additionalProperties": false
-		},
-		"avsender": {
-			"type": "object",
-			"properties": {
-				"organisasjon": {
-					"$ref": "#/definitions/organisasjon"
-				},
-				"person": {
-					"description": "Person som trykker på send til domstolen.",
-					"$ref": "#/definitions/ansattPerson"
-				}
-			},
-			"required": [
-				"organisasjon"
-			],
-			"additionalProperties": false
-		},
-		"dokument": {
-			"description": "Dokument som oversendes på justishub",
-			"type": "object",
-			"properties": {
-				"internId": {
-					"type": "string"
-				},
-				"kategori": {
-					"$ref": "#/definitions/kodeverk"
-				},
-				"overskrift": {
-					"type": "string"
-				},
-				"skrevetDato": {
-					"$ref": "#/definitions/dato"
-				},
-				"forsendelse": {
-					"$ref": "#/definitions/dokumentForsendelse"
-				}
-			},
-			"required": [
-				"overskrift",
-				"forsendelse"
-			],
-			"additionalProperties": false
-		},
-		"dokumentForsendelse": {
-			"description": "Detaljer om lokasjon og type",
-			"type": "object",
-			"properties": {
-				"mimeType": {
-					"type": "string"
-				},
-				"uri": {
-					"type": "string"
-				},
-				"sjekksum": {
-					"type": "string"
-				}
-			},
-			"required": [
-				"mimeType",
-				"uri",
-				"sjekksum"
-			],
-			"additionalProperties": false
-		},
-		"forsendelse": {
-			"type": "object",
-			"properties": {
-				"meldingsId": {
-					"type": "string"
-				},
-				"sendtTid": {
-					"$ref": "#/definitions/datoTid"
-				},
-				"avsender": {
-					"$ref": "#/definitions/avsender"
-				},
-				"mottakerOrganisasjon": {
-					"description": "Kriminalomsorg som skal være mottaker",
-					"$ref": "#/definitions/organisasjon"
-				}
-			},
-			"required": [
-				"meldingsId",
-				"sendtTid",
-				"avsender",
-				"mottakerOrganisasjon"
-			],
-			"additionalProperties": false
-		},
-		"fengsling": {
-			"description": "Fengsling som en del av kjennelsen, uten datoer så er det ikke noe fengsel nå.",
-			"type": "object",
-			"properties": {
-				"fengslingsId": {
-					"description": "fengslingsid som opprettes i DA (GUID)",
-					"type": "string"
-				},
-				"fraDato": {
-					"$ref": "#/definitions/dato"
-				},
-				"tilDato": {
-					"description": "Ikke utover gitt til-dato. Dvs til-og-med.",
-					"$ref": "#/definitions/dato"
-				},
-				"fengslingsFristDato": {
-					"$ref": "#/definitions/dato"
-				},
-				"lovbud": {
-					"$ref": "#/definitions/lovbudEnkel"
-				},
-				"merknad": {
-					"description": "Merknad til fengslingen",
-					"type": "string"
-				}
-			},
-			"required": [
-				"fengslingsId"
-			],
-			"additionalProperties": false
-		},
-		"foretak": {
-			"description": "Foretak/ organisasjon som er med i en straffesak som f.eks. fornærmet",
-			"type": "object",
-			"properties": {
-				"internId": {
-					"type": "string"
-				},
-				"organisasjonsnummer": {
-					"$ref": "#/definitions/organisasjonsnummer"
-				},
-				"navn": {
-					"type": "string"
-				},
-				"adresse": {
-					"$ref": "#/definitions/adresse"
-				}
-			},
-			"required": [
-				"internId",
-				"navn"
-			],
-			"additionalProperties": false
-		},
-		"isolasjon": {
-			"description": "Isolasjon fra domstolen, når vi har mottatt den, uten til fra dato kun når det er anke",
-			"type": "object",
-			"properties": {
-				"isolasjonsId": {
-					"description": "isolasjonsId som opprettes i DA (GUID)",
-					"type": "string"
-				},
-				"isolasjonsType": {
-					"$ref": "#/definitions/isolasjonsType"
-				},
-				"fraDato": {
-					"description": "Om begjæringen ikke tas til følge skal dette feltet settes til null.",
-					"$ref": "#/definitions/dato"
-				},
-				"tilDato": {
-					"description": "Om begjæringen ikke tas til følge skal dette feltet settes til null. Ikke utover gitt til-dato. Dvs til-og-med.",
-					"$ref": "#/definitions/dato"
-				}
-			},
-			"required": [
-				"isolasjonsId",
-				"isolasjonsType"
-			],
-			"additionalProperties": false
-		},
-		"isolasjonsType": {
-			"description": "Liste over de ulike isolasjonstyper",
-			"type": "string",
-			"enum": [
-				"FULL",
-				"DELVIS",
-				"INGEN"
-			]
-		},
-		"involverteStraffesak": {
-			"description": "siktede, vitner og fornærmede",
-			"type": "object",
-			"properties": {
-				"siktet": {
-					"$ref": "#/definitions/personEnkel"
-				},
-				"medsiktede": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/personForetak"
-					}
-				},
-				"fornaermede": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/personForetak"
-					}
-				},
-				"vitner": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/personVitne"
-					}
-				}
-			},
-			"required": [
-				"medsiktede",
-				"fornaermede",
-				"vitner"
-			],
-			"additionalProperties": false
-		},
-		"kodeverk": {
-			"type": "object",
-			"properties": {
-				"kode": {
-					"type": "string"
-				},
-				"navn": {
-					"type": "string"
-				}
-			},
-			"required": [
-				"kode"
-			],
-			"additionalProperties": false
-		},
-		"kontaktInfo": {
-			"type": "object",
-			"properties": {
-				"epost": {
-					"type": "string"
-				},
-				"telefonnummer": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/telefonnummer"
-					}
-				}
-			},
-			"required": [
-				"telefonnummer"
-			],
-			"additionalProperties": false
-		},
-		"kjennelseVaretekt": {
-			"description": "Kjennelse på varetektsfengsling fra domstolen som sendes videre til Kriminalomsorgen",
-			"type": "object",
-			"properties": {
-				"domstol": {
-					"$ref": "#/definitions/organisasjon"
-				},
-				"domstolsaktoerer": {
-					"$ref": "#/definitions/domstolsaktoerer"
-				},
-				"avgjoerelseId": {
-					"description": "Domstolen sin nøkkel til avgjørelsen. Kan bli brukt i forbindelse med anke/forlengelse",
-					"type": "string"
-				},
-				"kjennelseSendtTid": {
-					"description": "Tidspunktet kjennelsen ble sendt fra domstolen",
-					"$ref": "#/definitions/datoTid"
-				},
-				"avsagtDato": {
-					"$ref": "#/definitions/dato"
-				},
-				"kravid": {
-					"description": "Kravid som opprettes i politiet (begjæring om varetektsfengsling)",
-					"type": "string"
-				},
-				"personVaretektDomstol": {
-					"description": "Persondata fra domstolene, kan være forskjellig fra politiet sine data",
-					"$ref": "#/definitions/person"
-				},
-				"forlengelse": {
-					"description": "Forlengelse = true også hvis det er en endring i restriksjoner fra domstolene",
-					"type": "boolean"
-				},
-				"fengsling": {
-					"description": "Førstegangsfengslinger vil alltid inneholde fengsling, men senere kan det komme med kun restriksjoner, isolasjon.",
-					"$ref": "#/definitions/fengsling"
-				},
-				"restriksjoner": {
-					"type": "array",
-					"minItems": 1,
-					"items": {
-						"$ref": "#/definitions/restriksjon"
-					}
-				},
-				"isolasjonsKrav": {
-					"type": "array",
-					"minItems": 1,
-					"items": {
-						"$ref": "#/definitions/isolasjon"
-					}
-				},
-				"anke": {
-					"description": "Settes kun dersom hele eller deler av avgjørelsen ankes før kjennelsen sendes til påtale",
-					"$ref": "#/definitions/anke"
-				}
-			},
-			"required": [
-				"domstol",
-				"domstolsaktoerer",
-				"avgjoerelseId",
-				"kjennelseSendtTid",
-				"avsagtDato",
-				"kravid",
-				"personVaretektDomstol",
-				"forlengelse",
-				"restriksjoner",
-				"isolasjonsKrav"
-			],
-			"additionalProperties": false
-		},
-		"kjoenn": {
-			"description": "Samme enum som folkeregisteret",
-			"type": "string",
-			"enum": [
-				"KVINNE",
-				"MANN"
-			]
-		},
-		"personFregIdentifikator": {
-			"description": "Fødselsnummer eller D-nummer. I bruk på de som aldri vil ha SSP nummer",
-			"type": "object",
-			"properties": {
-				"foedselsnummer": {
-					"$ref": "#/definitions/foedselsnummer"
-				},
-				"dNummer": {
-					"$ref": "#/definitions/dNummer"
-				}
-			},
-			"oneOf": [
-				{
-					"properties": {
-						"foedselsnummer": {
-							"$ref": "#/definitions/foedselsnummer"
-						}
-					},
-					"required": [
-						"foedselsnummer"
-					],
-					"additionalProperties": false
-				},
-				{
-					"properties": {
-						"dNummer": {
-							"$ref": "#/definitions/dNummer"
-						}
-					},
-					"required": [
-						"dNummer"
-					],
-					"additionalProperties": false
-				}
-			]
-		},
-		"personIdentifikator": {
-			"description": "Fødselsnummer, D-nummer eller SSP nummer.",
-			"type": "object",
-			"properties": {
-				"foedselsnummer": {
-					"$ref": "#/definitions/foedselsnummer"
-				},
-				"sspNummer": {
-					"$ref": "#/definitions/sspNummer"
-				},
-				"dNummer": {
-					"$ref": "#/definitions/dNummer"
-				}
-			},
-			"oneOf": [
-				{
-					"properties": {
-						"foedselsnummer": {
-							"$ref": "#/definitions/foedselsnummer"
-						}
-					},
-					"required": [
-						"foedselsnummer"
-					],
-					"additionalProperties": false
-				},
-				{
-					"properties": {
-						"sspNummer": {
-							"$ref": "#/definitions/sspNummer"
-						}
-					},
-					"required": [
-						"sspNummer"
-					],
-					"additionalProperties": false
-				},
-				{
-					"properties": {
-						"dNummer": {
-							"$ref": "#/definitions/dNummer"
-						}
-					},
-					"required": [
-						"dNummer"
-					],
-					"additionalProperties": false
-				}
-			]
-		},
-		"lovbudEnkel": {
-			"description": "Enkel lovbudreferanse kun lovbudstreng",
-			"type": "object",
-			"properties": {
-				"lovbudId": {
-					"type": "string"
-				},
-				"lovbudStreng": {
-					"type": "string"
-				}
-			},
-			"required": [
-				"lovbudStreng"
-			],
-			"additionalProperties": false
-		},
-		"organisasjon": {
-			"description": "Entydig identifikator av juridisk enhet. F.eks en spesifik domstol eller kriminalomsorg",
-			"type": "object",
-			"properties": {
-				"navn": {
-					"description": "F.eks. Oslo politidistikt, Riksadvokaten, Borgarting lagmannsrett",
-					"type": "string"
-				},
-				"organisasjonsnummer": {
-					"$ref": "#/definitions/organisasjonsnummer"
-				}
-			},
-			"required": [
-				"navn",
-				"organisasjonsnummer"
-			],
-			"additionalProperties": false
-		},
-		"personnavn": {
-			"type": "object",
-			"properties": {
-				"fornavn": {
-					"type": "string"
-				},
-				"mellomnavn": {
-					"type": "string"
-				},
-				"etternavn": {
-					"type": "string"
-				}
-			},
-			"required": [
-				"etternavn"
-			],
-			"additionalProperties": false
-		},
-		"personForetak": {
-			"description": "En siktet eller fornærmet kan være en person eller et foretak, denne typen er enten person eller foretak.",
-			"type": "object",
-			"properties": {
-				"person": {
-					"$ref": "#/definitions/person"
-				},
-				"foretak": {
-					"$ref": "#/definitions/foretak"
-				}
-			},
-			"oneOf": [
-				{
-					"properties": {
-						"person": {
-							"$ref": "#/definitions/person"
-						}
-					},
-					"required": [
-						"person"
-					],
-					"additionalProperties": false
-				},
-				{
-					"properties": {
-						"foretak": {
-							"$ref": "#/definitions/foretak"
-						}
-					},
-					"required": [
-						"foretak"
-					],
-					"additionalProperties": false
-				}
-			]
-		},
-		"personAdresse": {
-			"description": "Kan være graderte adresser",
-			"type": "object",
-			"properties": {
-				"gradering": {
-					"$ref": "#/definitions/adresseGradering"
-				},
-				"adresse": {
-					"$ref": "#/definitions/adresse"
-				}
-			},
-			"required": [
-				"adresse"
-			],
-			"additionalProperties": false
-		},
-		"personVitne": {
-			"description": "Personer som er involverte, men ikke siktet. Kan være verger, vitner, etc.",
-			"type": "object",
-			"properties": {
-				"internId": {
-					"description": "Intern id i melding, samme person i denne meldingen vil ha samme internId",
-					"type": "string"
-				},
-				"navn": {
-					"$ref": "#/definitions/personnavn"
-				},
-				"foedselsdato": {
-					"type": "string",
-					"format": "date"
-				},
-				"kjoenn": {
-					"description": "Ukjent kjønn hvis denne ikke er med",
-					"$ref": "#/definitions/kjoenn"
-				},
-				"statsborgerskap": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/land"
-					}
-				},
-				"identitetsnummer": {
-					"description": "Fødselsnummer eller D-nummer. Vitner og verger skal aldri ha SSP nummer",
-					"$ref": "#/definitions/personFregIdentifikator"
-				},
-				"adresseGradering": {
-					"description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå",
-					"$ref": "#/definitions/adresseGradering"
-				},
-				"personAdresse": {
-					"$ref": "#/definitions/personAdresse"
-				}
-			},
-			"required": [
-				"internId",
-				"navn",
-				"statsborgerskap"
-			],
-			"additionalProperties": false
-		},
-		"person": {
-			"description": "Person med alle nyttige data som fødselsnummer adresse osv., SSP nummer kun på siktede, tiltalte.",
-			"type": "object",
-			"properties": {
-				"internId": {
-					"description": "Intern id i melding, samme person i denne meldingen vil ha samme internId",
-					"type": "string"
-				},
-				"navn": {
-					"$ref": "#/definitions/personnavn"
-				},
-				"foedselsdato": {
-					"$ref": "#/definitions/dato"
-				},
-				"kjoenn": {
-					"description": "Ukjent kjønn hvis denne ikke er med",
-					"$ref": "#/definitions/kjoenn"
-				},
-				"statsborgerskap": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/land"
-					}
-				},
-				"identitetsnummer": {
-					"description": "Fødselsnummer, D-nummer eller SSP nummer som er i bruk. Siktede vil alltid ha med denne.",
-					"$ref": "#/definitions/personIdentifikator"
-				},
-				"tilleggsId": {
-					"description": "Kan være SSP nummer hvis person har D-nummer, fremtidig historiske nummer?",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/personIdentifikator"
-					}
-				},
-				"adresseGradering": {
-					"description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå",
-					"$ref": "#/definitions/adresseGradering"
-				},
-				"personAdresse": {
-					"$ref": "#/definitions/personAdresse"
-				},
-				"verger": {
-					"description": "Verge skal være med på siktet, fornærmet, vitne.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/personRelatert"
-					}
-				}
-			},
-			"required": [
-				"internId",
-				"navn",
-				"statsborgerskap",
-				"tilleggsId",
-				"verger"
-			],
-			"additionalProperties": false
-		},
-		"personEnkel": {
-			"description": "Kun navn og fødselsdato (hvis den finnes)",
-			"type": "object",
-			"properties": {
-				"internId": {
-					"description": "Intern som peker på samme person i en spesifikk melding",
-					"type": "string"
-				},
-				"navn": {
-					"$ref": "#/definitions/personnavn"
-				},
-				"foedselsdato": {
-					"$ref": "#/definitions/dato"
-				}
-			},
-			"required": [
-				"internId",
-				"navn"
-			],
-			"additionalProperties": false
-		},
-		"personRelatert": {
-			"description": "Personer relatert til straffesaken som verger og advokater",
-			"type": "object",
-			"properties": {
-				"internId": {
-					"description": "Intern id i melding, samme person i denne meldingen vil ha samme internId, en verge kan f.eks. også være vitne i saken",
-					"type": "string"
-				},
-				"tittel": {
-					"type": "string"
-				},
-				"navn": {
-					"$ref": "#/definitions/personnavn"
-				},
-				"foedselsdato": {
-					"description": "På de vi har det, sjekke om vi kan dele",
-					"$ref": "#/definitions/dato"
-				},
-				"kjoenn": {
-					"description": "Ukjent kjønn hvis denne ikke er med",
-					"$ref": "#/definitions/kjoenn"
-				},
-				"foedselsnummer": {
-					"description": "Fødselsnummer f.eks på verger. Vil ikke være utfylt på advokater.",
-					"$ref": "#/definitions/foedselsnummer"
-				}
-			},
-			"required": [
-				"internId",
-				"navn"
-			],
-			"additionalProperties": false
-		},
-		"restriksjon": {
-			"description": "Restriksjon fra domstolen, når vi har mottatt den, uten til fra dato kun når det er anke",
-			"type": "object",
-			"properties": {
-				"restriksjonsId": {
-					"description": "restriksjonsId som opprettes i DA (GUID)",
-					"type": "string"
-				},
-				"restriksjonsType": {
-					"$ref": "#/definitions/restriksjonsType"
-				},
-				"fraDato": {
-					"description": "Om begjæringen ikke tas til følge er dette feltet satt til null.",
-					"$ref": "#/definitions/dato"
-				},
-				"tilDato": {
-					"description": "Om begjæringen ikke tas til følge er dette feltet satt til null. Ikke utover gitt til-dato. Dvs til-og-med.",
-					"$ref": "#/definitions/dato"
-				}
-			},
-			"required": [
-				"restriksjonsId",
-				"restriksjonsType"
-			],
-			"additionalProperties": false
-		},
-		"restriksjonsType": {
-			"description": "Liste over de ulike restriksjonene",
-			"type": "string",
-			"enum": [
-				"BREV_OG_BESOEKSFORBUD",
-				"BREV_OG_BESOEKSKONTROLL",
-				"MEDIEFORBUD",
-				"INGEN"
-			]
-		},
-		"straffesakInvolverte": {
-			"description": "Straffesak med statistikkgrupper, krimtype og de involverte",
-			"type": "object",
-			"properties": {
-				"straffesaksnummer": {
-					"$ref": "#/definitions/straffesaksnummer"
-				},
-				"detaljer": {
-					"$ref": "#/definitions/straffesakDetaljer"
-				},
-				"involverte": {
-					"$ref": "#/definitions/involverteStraffesak"
-				}
-			},
-			"required": [
-				"straffesaksnummer",
-				"detaljer",
-				"involverte"
-			],
-			"additionalProperties": false
-		},
-		"domstolsaktoerer": {
-			"description": "Aktører fra domstolen",
-			"type": "object",
-			"properties": {
-				"dommer": {
-					"description": "Dommer på saken",
-					"$ref": "#/definitions/ansattPerson"
-				},
-				"saksbehandler": {
-					"description": "Saksbehandler på saken",
-					"$ref": "#/definitions/ansattPerson"
-				}
-			},
-			"required": [
-				"dommer"
-			],
-			"additionalProperties": false
-		},
-		"straffesakDetaljer": {
-			"description": "Detaljer rundt straffesaken, OBS krimType er ikke klart ennå-.s",
-			"type": "object",
-			"properties": {
-				"hendelse": {
-					"$ref": "#/definitions/hendelse"
-				},
-				"statistikkgruppe": {
-					"$ref": "#/definitions/kodeverk"
-				},
-				"krimtype": {
-					"$ref": "#/definitions/kodeverk"
-				}
-			},
-			"required": [
-				"hendelse",
-				"statistikkgruppe"
-			],
-			"additionalProperties": false
-		},
-		"hendelse": {
-			"description": "Tid og sted for den straffbare handlingen",
-			"type": "object",
-			"properties": {
-				"gjerningstidspunktFra": {
-					"$ref": "#/definitions/datoTid"
-				},
-				"gjerningstidspunktTil": {
-					"$ref": "#/definitions/datoTid"
-				},
-				"gjerningssted": {
-					"$ref": "#/definitions/adresse"
-				}
-			},
-			"required": [
-				"gjerningstidspunktFra",
-				"gjerningstidspunktTil",
-				"gjerningssted"
-			],
-			"additionalProperties": false
-		},
-		"land": {
-			"description": "ISO-3166, Kosovo kommer",
-			"type": "object",
-			"properties": {
-				"kode": {
-					"type": "string",
-					"minLength": 3,
-					"maxLength": 3,
-					"pattern": "^[A-Z]+$"
-				},
-				"navn": {
-					"type": "string"
-				}
-			},
-			"required": [
-				"kode"
-			],
-			"additionalProperties": false
-		},
-		"straffesaksnummer": {
-			"description": "Som regel et løpenummer, men kan i fremtiden også inneholde bokstaver",
-			"type": "string",
-			"minLength": 3,
-			"maxLength": 30
-		},
-		"telefonnummer": {
-			"description": "Ett telefonnummer, norsk eller utenlands, med eller uten land prefix",
-			"type": "string",
-			"minLength": 1,
-			"maxLength": 30
-		},
-		"foedselsnummer": {
-			"description": "Se skatteetaten. Kan være vanlig med 6 sifret fødselsdato og fiktivt (Tenor) fødselsnummer med +80 på måned slik at noen født 10.01.1990 begynner fiktivt nummer med 108190",
-			"type": "string",
-			"minLength": 11,
-			"maxLength": 11,
-			"pattern": "^[0-3][0-9][0189][0-9]+$"
-		},
-		"sspNummer": {
-			"description": "Personidentifikator brukt av det sentrale straffe- og personopplysningsregisteret (SSP) hvis personen ikke har fødselsnummer. Validerer som et fødselsnummer med +20 på måned så noen født 10.01.1990 begynner med 102190",
-			"type": "string",
-			"minLength": 11,
-			"maxLength": 11,
-			"pattern": "^[0-3][0-9][2-3][0-9]+$"
-		},
-		"dNummer": {
-			"description": "Se skatteetaten. Dag på datodelen er +40. Født 10.01.1990, begynner med 51.01.90. Fiktivt (Tenor) dNummer vil har +80 på måned som for Tenor fødselsnummer",
-			"type": "string",
-			"minLength": 11,
-			"maxLength": 11,
-			"pattern": "^[4-7][0-9][0189][0-9]+$"
-		},
-		"organisasjonsnummer": {
-			"description": "Norsk organisasjonsnummer fra BRREG. Referanse til politistrikt, domstol, fengsel. https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/organisasjonsnummeret/",
-			"type": "string",
-			"minLength": 9,
-			"maxLength": 9,
-			"pattern": "^[0-9]+$"
-		},
-		"unikId": {
-			"description": "GUID eller andre unike id'er. Trenger ikke være global unik.",
-			"type": "string",
-			"minLength": 1,
-			"maxLength": 40
-		},
-		"datoTid": {
-			"type": "string",
-			"format": "date-time"
-		},
-		"dato": {
-			"type": "string",
-			"format": "date"
-		}
-	}
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://politiet.no/politi/kjennelseVaretektPoliti/arbeidsversjon/kjennelseVaretektPoliti",
+  "description": "Kjennelse fra domstolen førtegangsfengsling eller forlengelser.",
+  "type": "object",
+  "properties": {
+    "forsendelse": {
+      "description": "avsender og mottaker",
+      "$ref": "#/definitions/forsendelse"
+    },
+    "hovedStraffesaksnummer": {
+      "description": "BL Saksbehandlersak er hovedsaken i et sakskompleks (som er 1 eller flere straffesaker)",
+      "$ref": "#/definitions/straffesaksnummer"
+    },
+    "varetektSyklusId": {
+      "description": "En syklus fra pågripelse til løslatelse, vil ikke være med til å begynne med",
+      "$ref": "#/definitions/unikId"
+    },
+    "personVaretektInfo": {
+      "$ref": "#/definitions/personVaretektInfo"
+    },
+    "kjennelseVaretekt": {
+      "$ref": "#/definitions/kjennelseVaretekt"
+    },
+    "paagrepetSted": {
+      "description": "Sted for pågripelse. Vil være satt i ca 20% av tilfellene",
+      "type": "string"
+    },
+    "paagrepetTidspunkt": {
+      "$ref": "#/definitions/datoTid"
+    },
+    "dokumenter": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/dokument"
+      }
+    }
+  },
+  "required": [
+    "forsendelse",
+    "hovedStraffesaksnummer",
+    "personVaretektInfo",
+    "kjennelseVaretekt",
+    "dokumenter"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "adresse": {
+      "type": "object",
+      "properties": {
+        "adresselinjer": {
+          "type": "array",
+          "contains": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "minContains": 1,
+          "maxContains": 4
+        },
+        "postnummer": {
+          "type": "string"
+        },
+        "poststed": {
+          "type": "string"
+        },
+        "land": {
+          "$ref": "#/definitions/land"
+        }
+      },
+      "required": ["adresselinjer"],
+      "additionalProperties": false
+    },
+    "adresseGradering": {
+      "description": "Samme enum som folkeregisteret, ugradert hvis den ikke er gradert",
+      "type": "string",
+      "enum": ["KLIENT_ADRESSE", "FORTROLIG", "STRENGT_FORTROLIG"]
+    },
+    "personVaretektInfo": {
+      "description": "Data om personen og straffesaker personen er involvert i",
+      "type": "object",
+      "properties": {
+        "personVaretekt": {
+          "description": "Straffesak personen, forskjeller ser du ved å sammenligne med data fra domstolen",
+          "$ref": "#/definitions/person"
+        },
+        "straffesaker": {
+          "title": "straffesaker",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/straffesakInvolverte"
+          }
+        }
+      },
+      "required": ["personVaretekt", "straffesaker"],
+      "additionalProperties": false
+    },
+    "anke": {
+      "description": "Anke av fengsling/restriksjon/kjennelse",
+      "type": "object",
+      "properties": {
+        "anketDato": {
+          "$ref": "#/definitions/dato"
+        },
+        "oppsettendeVirkning": {
+          "type": "boolean"
+        }
+      },
+      "required": ["anketDato"],
+      "additionalProperties": false
+    },
+    "ansattPerson": {
+      "description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
+      "type": "object",
+      "properties": {
+        "tittel": {
+          "type": "string"
+        },
+        "fornavn": {
+          "type": "string"
+        },
+        "mellomnavn": {
+          "type": "string"
+        },
+        "etternavn": {
+          "type": "string"
+        },
+        "kontakt": {
+          "description": "Er ikke med i første fase, burde inneholde kontaktinformasjon på forsendelsen.",
+          "$ref": "#/definitions/kontaktInfo"
+        }
+      },
+      "required": ["etternavn"],
+      "additionalProperties": false
+    },
+    "avsender": {
+      "type": "object",
+      "properties": {
+        "organisasjon": {
+          "$ref": "#/definitions/organisasjon"
+        },
+        "person": {
+          "description": "Person som trykker på send til domstolen.",
+          "$ref": "#/definitions/ansattPerson"
+        }
+      },
+      "required": ["organisasjon"],
+      "additionalProperties": false
+    },
+    "dokument": {
+      "description": "Dokument som oversendes på justishub",
+      "type": "object",
+      "properties": {
+        "internId": {
+          "type": "string"
+        },
+        "kategori": {
+          "$ref": "#/definitions/kodeverk"
+        },
+        "overskrift": {
+          "type": "string"
+        },
+        "skrevetDato": {
+          "$ref": "#/definitions/dato"
+        },
+        "forsendelse": {
+          "$ref": "#/definitions/dokumentForsendelse"
+        }
+      },
+      "required": ["overskrift", "forsendelse"],
+      "additionalProperties": false
+    },
+    "dokumentForsendelse": {
+      "description": "Detaljer om lokasjon og type",
+      "type": "object",
+      "properties": {
+        "mimeType": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "sjekksum": {
+          "type": "string"
+        }
+      },
+      "required": ["mimeType", "uri", "sjekksum"],
+      "additionalProperties": false
+    },
+    "forsendelse": {
+      "type": "object",
+      "properties": {
+        "meldingsId": {
+          "type": "string"
+        },
+        "sendtTid": {
+          "$ref": "#/definitions/datoTid"
+        },
+        "avsender": {
+          "$ref": "#/definitions/avsender"
+        },
+        "mottakerOrganisasjon": {
+          "description": "Kriminalomsorg som skal være mottaker",
+          "$ref": "#/definitions/organisasjon"
+        }
+      },
+      "required": [
+        "meldingsId",
+        "sendtTid",
+        "avsender",
+        "mottakerOrganisasjon"
+      ],
+      "additionalProperties": false
+    },
+    "fengsling": {
+      "description": "Fengsling som en del av kjennelsen, uten datoer så er det ikke noe fengsel nå.",
+      "type": "object",
+      "properties": {
+        "fengslingsId": {
+          "description": "fengslingsid som opprettes i DA (GUID)",
+          "type": "string"
+        },
+        "fraDato": {
+          "$ref": "#/definitions/dato"
+        },
+        "tilDato": {
+          "description": "Ikke utover gitt til-dato. Dvs til-og-med.",
+          "$ref": "#/definitions/dato"
+        },
+        "fengslingsFristDato": {
+          "$ref": "#/definitions/dato"
+        },
+        "lovbud": {
+          "$ref": "#/definitions/lovbudEnkel"
+        },
+        "merknad": {
+          "description": "Merknad til fengslingen",
+          "type": "string"
+        }
+      },
+      "required": ["fengslingsId"],
+      "additionalProperties": false
+    },
+    "foretak": {
+      "description": "Foretak/ organisasjon som er med i en straffesak som f.eks. fornærmet",
+      "type": "object",
+      "properties": {
+        "internId": {
+          "type": "string"
+        },
+        "organisasjonsnummer": {
+          "$ref": "#/definitions/organisasjonsnummer"
+        },
+        "navn": {
+          "type": "string"
+        },
+        "adresse": {
+          "$ref": "#/definitions/adresse"
+        }
+      },
+      "required": ["internId", "navn"],
+      "additionalProperties": false
+    },
+    "isolasjon": {
+      "description": "Isolasjon fra domstolen, når vi har mottatt den, uten til fra dato kun når det er anke",
+      "type": "object",
+      "properties": {
+        "isolasjonsId": {
+          "description": "isolasjonsId som opprettes i DA (GUID)",
+          "type": "string"
+        },
+        "isolasjonsType": {
+          "$ref": "#/definitions/isolasjonsType"
+        },
+        "fraDato": {
+          "description": "Om begjæringen ikke tas til følge skal dette feltet settes til null.",
+          "$ref": "#/definitions/dato"
+        },
+        "tilDato": {
+          "description": "Om begjæringen ikke tas til følge skal dette feltet settes til null. Ikke utover gitt til-dato. Dvs til-og-med.",
+          "$ref": "#/definitions/dato"
+        }
+      },
+      "required": ["isolasjonsId", "isolasjonsType"],
+      "additionalProperties": false
+    },
+    "isolasjonsType": {
+      "description": "Liste over de ulike isolasjonstyper",
+      "type": "string",
+      "enum": ["FULL", "DELVIS", "INGEN"]
+    },
+    "involverteStraffesak": {
+      "description": "siktede, vitner og fornærmede",
+      "type": "object",
+      "properties": {
+        "siktet": {
+          "$ref": "#/definitions/personEnkel"
+        },
+        "medsiktede": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personForetak"
+          }
+        },
+        "fornaermede": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personForetak"
+          }
+        },
+        "vitner": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personVitne"
+          }
+        }
+      },
+      "required": ["medsiktede", "fornaermede", "vitner"],
+      "additionalProperties": false
+    },
+    "kodeverk": {
+      "type": "object",
+      "properties": {
+        "kode": {
+          "type": "string"
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["kode"],
+      "additionalProperties": false
+    },
+    "kontaktInfo": {
+      "type": "object",
+      "properties": {
+        "epost": {
+          "type": "string"
+        },
+        "telefonnummer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/telefonnummer"
+          }
+        }
+      },
+      "required": ["telefonnummer"],
+      "additionalProperties": false
+    },
+    "kjennelseVaretekt": {
+      "description": "Kjennelse på varetektsfengsling fra domstolen som sendes videre til Kriminalomsorgen",
+      "type": "object",
+      "properties": {
+        "domstol": {
+          "$ref": "#/definitions/organisasjon"
+        },
+        "domstolsaktoerer": {
+          "$ref": "#/definitions/domstolsaktoerer"
+        },
+        "avgjoerelseId": {
+          "description": "Domstolen sin nøkkel til avgjørelsen. Kan bli brukt i forbindelse med anke/forlengelse",
+          "type": "string"
+        },
+        "kjennelseSendtTid": {
+          "description": "Tidspunktet kjennelsen ble sendt fra domstolen",
+          "$ref": "#/definitions/datoTid"
+        },
+        "avsagtDato": {
+          "$ref": "#/definitions/dato"
+        },
+        "kravid": {
+          "description": "Kravid som opprettes i politiet (begjæring om varetektsfengsling)",
+          "type": "string"
+        },
+        "personVaretektDomstol": {
+          "description": "Persondata fra domstolene, kan være forskjellig fra politiet sine data",
+          "$ref": "#/definitions/person"
+        },
+        "forlengelse": {
+          "description": "Forlengelse = true også hvis det er en endring i restriksjoner fra domstolene",
+          "type": "boolean"
+        },
+        "fengsling": {
+          "description": "Førstegangsfengslinger vil alltid inneholde fengsling, men senere kan det komme med kun restriksjoner, isolasjon.",
+          "$ref": "#/definitions/fengsling"
+        },
+        "restriksjoner": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/restriksjon"
+          }
+        },
+        "isolasjonsKrav": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/isolasjon"
+          }
+        },
+        "anke": {
+          "description": "Settes kun dersom hele eller deler av avgjørelsen ankes før kjennelsen sendes til påtale",
+          "$ref": "#/definitions/anke"
+        }
+      },
+      "required": [
+        "domstol",
+        "domstolsaktoerer",
+        "avgjoerelseId",
+        "kjennelseSendtTid",
+        "avsagtDato",
+        "kravid",
+        "personVaretektDomstol",
+        "forlengelse",
+        "restriksjoner",
+        "isolasjonsKrav"
+      ],
+      "additionalProperties": false
+    },
+    "kjoenn": {
+      "description": "Samme enum som folkeregisteret",
+      "type": "string",
+      "enum": ["KVINNE", "MANN"]
+    },
+    "personFregIdentifikator": {
+      "description": "Fødselsnummer eller D-nummer. I bruk på de som aldri vil ha SSP nummer",
+      "type": "object",
+      "properties": {
+        "foedselsnummer": {
+          "$ref": "#/definitions/foedselsnummer"
+        },
+        "dNummer": {
+          "$ref": "#/definitions/dNummer"
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "foedselsnummer": {
+              "$ref": "#/definitions/foedselsnummer"
+            }
+          },
+          "required": ["foedselsnummer"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "dNummer": {
+              "$ref": "#/definitions/dNummer"
+            }
+          },
+          "required": ["dNummer"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "personIdentifikator": {
+      "description": "Fødselsnummer, D-nummer eller SSP nummer.",
+      "type": "object",
+      "properties": {
+        "foedselsnummer": {
+          "$ref": "#/definitions/foedselsnummer"
+        },
+        "sspNummer": {
+          "$ref": "#/definitions/sspNummer"
+        },
+        "dNummer": {
+          "$ref": "#/definitions/dNummer"
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "foedselsnummer": {
+              "$ref": "#/definitions/foedselsnummer"
+            }
+          },
+          "required": ["foedselsnummer"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "sspNummer": {
+              "$ref": "#/definitions/sspNummer"
+            }
+          },
+          "required": ["sspNummer"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "dNummer": {
+              "$ref": "#/definitions/dNummer"
+            }
+          },
+          "required": ["dNummer"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "lovbudEnkel": {
+      "description": "Enkel lovbudreferanse kun lovbudstreng",
+      "type": "object",
+      "properties": {
+        "lovbudId": {
+          "type": "string"
+        },
+        "lovbudStreng": {
+          "type": "string"
+        }
+      },
+      "required": ["lovbudStreng"],
+      "additionalProperties": false
+    },
+    "organisasjon": {
+      "description": "Entydig identifikator av juridisk enhet. F.eks en spesifik domstol eller kriminalomsorg",
+      "type": "object",
+      "properties": {
+        "navn": {
+          "description": "F.eks. Oslo politidistikt, Riksadvokaten, Borgarting lagmannsrett",
+          "type": "string"
+        },
+        "organisasjonsnummer": {
+          "$ref": "#/definitions/organisasjonsnummer"
+        }
+      },
+      "required": ["navn", "organisasjonsnummer"],
+      "additionalProperties": false
+    },
+    "personnavn": {
+      "type": "object",
+      "properties": {
+        "fornavn": {
+          "type": "string"
+        },
+        "mellomnavn": {
+          "type": "string"
+        },
+        "etternavn": {
+          "type": "string"
+        }
+      },
+      "required": ["etternavn"],
+      "additionalProperties": false
+    },
+    "personForetak": {
+      "description": "En siktet eller fornærmet kan være en person eller et foretak, denne typen er enten person eller foretak.",
+      "type": "object",
+      "properties": {
+        "person": {
+          "$ref": "#/definitions/person"
+        },
+        "foretak": {
+          "$ref": "#/definitions/foretak"
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "person": {
+              "$ref": "#/definitions/person"
+            }
+          },
+          "required": ["person"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "foretak": {
+              "$ref": "#/definitions/foretak"
+            }
+          },
+          "required": ["foretak"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "personAdresse": {
+      "description": "Kan være graderte adresser",
+      "type": "object",
+      "properties": {
+        "gradering": {
+          "$ref": "#/definitions/adresseGradering"
+        },
+        "adresse": {
+          "$ref": "#/definitions/adresse"
+        }
+      },
+      "required": ["adresse"],
+      "additionalProperties": false
+    },
+    "personVitne": {
+      "description": "Personer som er involverte, men ikke siktet. Kan være verger, vitner, etc.",
+      "type": "object",
+      "properties": {
+        "internId": {
+          "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId",
+          "type": "string"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": {
+          "type": "string",
+          "format": "date"
+        },
+        "kjoenn": {
+          "description": "Ukjent kjønn hvis denne ikke er med",
+          "$ref": "#/definitions/kjoenn"
+        },
+        "statsborgerskap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/land"
+          }
+        },
+        "identitetsnummer": {
+          "description": "Fødselsnummer eller D-nummer. Vitner og verger skal aldri ha SSP nummer",
+          "$ref": "#/definitions/personFregIdentifikator"
+        },
+        "adresseGradering": {
+          "description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå",
+          "$ref": "#/definitions/adresseGradering"
+        },
+        "personAdresse": {
+          "$ref": "#/definitions/personAdresse"
+        }
+      },
+      "required": ["internId", "navn", "statsborgerskap"],
+      "additionalProperties": false
+    },
+    "person": {
+      "description": "Person med alle nyttige data som fødselsnummer adresse osv., SSP nummer kun på siktede, tiltalte.",
+      "type": "object",
+      "properties": {
+        "internId": {
+          "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId",
+          "type": "string"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": {
+          "$ref": "#/definitions/dato"
+        },
+        "kjoenn": {
+          "description": "Ukjent kjønn hvis denne ikke er med",
+          "$ref": "#/definitions/kjoenn"
+        },
+        "statsborgerskap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/land"
+          }
+        },
+        "identitetsnummer": {
+          "description": "Fødselsnummer, D-nummer eller SSP nummer som er i bruk. Siktede vil alltid ha med denne.",
+          "$ref": "#/definitions/personIdentifikator"
+        },
+        "tilleggsId": {
+          "description": "Kan være SSP nummer hvis person har D-nummer, fremtidig historiske nummer?",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personIdentifikator"
+          }
+        },
+        "adresseGradering": {
+          "description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå",
+          "$ref": "#/definitions/adresseGradering"
+        },
+        "personAdresse": {
+          "$ref": "#/definitions/personAdresse"
+        },
+        "verger": {
+          "description": "Verge skal være med på siktet, fornærmet, vitne.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personRelatert"
+          }
+        }
+      },
+      "required": [
+        "internId",
+        "navn",
+        "statsborgerskap",
+        "tilleggsId",
+        "verger"
+      ],
+      "additionalProperties": false
+    },
+    "personEnkel": {
+      "description": "Kun navn og fødselsdato (hvis den finnes)",
+      "type": "object",
+      "properties": {
+        "internId": {
+          "description": "Intern som peker på samme person i en spesifikk melding",
+          "type": "string"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": {
+          "$ref": "#/definitions/dato"
+        }
+      },
+      "required": ["internId", "navn"],
+      "additionalProperties": false
+    },
+    "personRelatert": {
+      "description": "Personer relatert til straffesaken som verger og advokater",
+      "type": "object",
+      "properties": {
+        "internId": {
+          "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId, en verge kan f.eks. også være vitne i saken",
+          "type": "string"
+        },
+        "tittel": {
+          "type": "string"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": {
+          "description": "På de vi har det, sjekke om vi kan dele",
+          "$ref": "#/definitions/dato"
+        },
+        "kjoenn": {
+          "description": "Ukjent kjønn hvis denne ikke er med",
+          "$ref": "#/definitions/kjoenn"
+        },
+        "foedselsnummer": {
+          "description": "Fødselsnummer f.eks på verger. Vil ikke være utfylt på advokater.",
+          "$ref": "#/definitions/foedselsnummer"
+        }
+      },
+      "required": ["internId", "navn"],
+      "additionalProperties": false
+    },
+    "restriksjon": {
+      "description": "Restriksjon fra domstolen, når vi har mottatt den, uten til fra dato kun når det er anke",
+      "type": "object",
+      "properties": {
+        "restriksjonsId": {
+          "description": "restriksjonsId som opprettes i DA (GUID)",
+          "type": "string"
+        },
+        "restriksjonsType": {
+          "$ref": "#/definitions/restriksjonsType"
+        },
+        "fraDato": {
+          "description": "Om begjæringen ikke tas til følge er dette feltet satt til null.",
+          "$ref": "#/definitions/dato"
+        },
+        "tilDato": {
+          "description": "Om begjæringen ikke tas til følge er dette feltet satt til null. Ikke utover gitt til-dato. Dvs til-og-med.",
+          "$ref": "#/definitions/dato"
+        }
+      },
+      "required": ["restriksjonsId", "restriksjonsType"],
+      "additionalProperties": false
+    },
+    "restriksjonsType": {
+      "description": "Liste over de ulike restriksjonene",
+      "type": "string",
+      "enum": [
+        "BREV_OG_BESOEKSFORBUD",
+        "BREV_OG_BESOEKSKONTROLL",
+        "MEDIEFORBUD",
+        "INGEN"
+      ]
+    },
+    "straffesakInvolverte": {
+      "description": "Straffesak med statistikkgrupper, krimtype og de involverte",
+      "type": "object",
+      "properties": {
+        "straffesaksnummer": {
+          "$ref": "#/definitions/straffesaksnummer"
+        },
+        "detaljer": {
+          "$ref": "#/definitions/straffesakDetaljer"
+        },
+        "involverte": {
+          "$ref": "#/definitions/involverteStraffesak"
+        }
+      },
+      "required": ["straffesaksnummer", "detaljer", "involverte"],
+      "additionalProperties": false
+    },
+    "domstolsaktoerer": {
+      "description": "Aktører fra domstolen",
+      "type": "object",
+      "properties": {
+        "dommer": {
+          "description": "Dommer på saken",
+          "$ref": "#/definitions/ansattPerson"
+        },
+        "saksbehandler": {
+          "description": "Saksbehandler på saken",
+          "$ref": "#/definitions/ansattPerson"
+        }
+      },
+      "required": ["dommer"],
+      "additionalProperties": false
+    },
+    "straffesakDetaljer": {
+      "description": "Detaljer rundt straffesaken, OBS krimType er ikke klart ennå-.s",
+      "type": "object",
+      "properties": {
+        "hendelse": {
+          "$ref": "#/definitions/hendelse"
+        },
+        "statistikkgruppe": {
+          "$ref": "#/definitions/kodeverk"
+        },
+        "krimtype": {
+          "$ref": "#/definitions/kodeverk"
+        }
+      },
+      "required": ["hendelse", "statistikkgruppe"],
+      "additionalProperties": false
+    },
+    "hendelse": {
+      "description": "Tid og sted for den straffbare handlingen",
+      "type": "object",
+      "properties": {
+        "gjerningstidspunktFra": {
+          "$ref": "#/definitions/datoTid"
+        },
+        "gjerningstidspunktTil": {
+          "$ref": "#/definitions/datoTid"
+        },
+        "gjerningssted": {
+          "$ref": "#/definitions/adresse"
+        }
+      },
+      "required": [
+        "gjerningstidspunktFra",
+        "gjerningstidspunktTil",
+        "gjerningssted"
+      ],
+      "additionalProperties": false
+    },
+    "land": {
+      "description": "ISO-3166, Kosovo kommer",
+      "type": "object",
+      "properties": {
+        "kode": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 3,
+          "pattern": "^[A-Z]+$"
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["kode"],
+      "additionalProperties": false
+    },
+    "straffesaksnummer": {
+      "description": "Som regel et løpenummer, men kan i fremtiden også inneholde bokstaver",
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 30
+    },
+    "telefonnummer": {
+      "description": "Ett telefonnummer, norsk eller utenlands, med eller uten land prefix",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 30
+    },
+    "foedselsnummer": {
+      "description": "Se skatteetaten. Kan være vanlig med 6 sifret fødselsdato og fiktivt (Tenor) fødselsnummer med +80 på måned slik at noen født 10.01.1990 begynner fiktivt nummer med 108190",
+      "type": "string",
+      "minLength": 11,
+      "maxLength": 11,
+      "pattern": "^[0-3][0-9][0189][0-9]+$"
+    },
+    "sspNummer": {
+      "description": "Personidentifikator brukt av det sentrale straffe- og personopplysningsregisteret (SSP) hvis personen ikke har fødselsnummer. Validerer som et fødselsnummer med +20 på måned så noen født 10.01.1990 begynner med 102190",
+      "type": "string",
+      "minLength": 11,
+      "maxLength": 11,
+      "pattern": "^[0-3][0-9][2-3][0-9]+$"
+    },
+    "dNummer": {
+      "description": "Se skatteetaten. Dag på datodelen er +40. Født 10.01.1990, begynner med 51.01.90. Fiktivt (Tenor) dNummer vil har +80 på måned som for Tenor fødselsnummer",
+      "type": "string",
+      "minLength": 11,
+      "maxLength": 11,
+      "pattern": "^[4-7][0-9][0189][0-9]+$"
+    },
+    "organisasjonsnummer": {
+      "description": "Norsk organisasjonsnummer fra BRREG. Referanse til politistrikt, domstol, fengsel. https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/organisasjonsnummeret/",
+      "type": "string",
+      "minLength": 9,
+      "maxLength": 9,
+      "pattern": "^[0-9]+$"
+    },
+    "unikId": {
+      "description": "GUID eller andre unike id'er. Trenger ikke være global unik.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 40
+    },
+    "datoTid": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "dato": {
+      "type": "string",
+      "format": "date"
+    }
+  }
 }


### PR DESCRIPTION
Disse feltene ble, om jeg husker riktig, gjort om fra dato-tid, til kun dato. 
Da gikk verdien for eksempel fra `10.01.2023 14:00` til `10.01.2023` og vi mistet i noen tilfeller noen timer. 
Ordlyden kunne potensielt vært endra fra `til -> tilOgMed` den gangen, men slik ble det ikke.   

Legger på description på felt i kontrakten for fengsling/restriksjon/isolasjon for å presisere at forventningen er at dommer bruker ordlyden "ikke utover dato" som i praksis betyr: 

"Dommer bestemmer at siktede skal ilegges brev og besøksforbud, [så lenge som det er nødvendig], men ikke utover tirsdag 10.01.2023"

Altså at det opphører en eller annen gang i løpet av kontortiden tirsdag 10.01.2023, eller før om det kommer en oppdatering på det. 

Dersom det er ulik praksis på dette rundt om, så er altså dette ny forventning om "standard" måte å ordlegge seg. 
Ordlyden "..inntil dato" utgår, til fordel for "...ikke utover dato..". 