### PR TITLE
Nærmere beskrivelse av at til-dato nå betyr til-og-med eller "ikke-utover-denne-dato"..

### DIFF
--- a/kontrakter/politi/kjennelsevaretektpoliti/arbeidsversjon/kjennelseVaretektPoliti.schema.json
+++ b/kontrakter/politi/kjennelsevaretektpoliti/arbeidsversjon/kjennelseVaretektPoliti.schema.json
@@ -176,7 +176,10 @@
           "description": "fengslingsid som opprettes i DA (GUID)"
         },
         "fraDato": { "$ref": "#/definitions/dato" },
-        "tilDato": { "$ref": "#/definitions/dato" },
+        "tilDato": {
+          "$ref": "#/definitions/dato",
+          "description": "Ikke utover gitt til-dato. Dvs til-og-med."
+        }
         "fengslingsFristDato": { "$ref": "#/definitions/dato" },
         "lovbud": { "$ref": "#/definitions/lovbudEnkel" },
         "merknad": {
@@ -216,7 +219,7 @@
         },
         "tilDato": {
           "$ref": "#/definitions/dato",
-          "description": "Om begjæringen ikke tas til følge skal dette feltet settes til null."
+          "description": "Om begjæringen ikke tas til følge skal dette feltet settes til null. Ikke utover gitt til-dato. Dvs til-og-med."
         }
       },
       "required": ["isolasjonsId", "isolasjonsType"],
@@ -609,7 +612,7 @@
           "$ref": "#/definitions/dato"
         },
         "tilDato": {
-          "description": "Om begjæringen ikke tas til følge er dette feltet satt til null.",
+          "description": "Om begjæringen ikke tas til følge er dette feltet satt til null. Ikke utover gitt til-dato. Dvs til-og-med.",
           "$ref": "#/definitions/dato"
         }
       },

--- a/kontrakter/politi/kjennelsevaretektpoliti/arbeidsversjon/kjennelseVaretektPoliti.schema.json
+++ b/kontrakter/politi/kjennelsevaretektpoliti/arbeidsversjon/kjennelseVaretektPoliti.schema.json
@@ -179,7 +179,7 @@
         "tilDato": {
           "$ref": "#/definitions/dato",
           "description": "Ikke utover gitt til-dato. Dvs til-og-med."
-        }
+        },
         "fengslingsFristDato": { "$ref": "#/definitions/dato" },
         "lovbud": { "$ref": "#/definitions/lovbudEnkel" },
         "merknad": {


### PR DESCRIPTION
Disse feltene ble, om jeg husker riktig, gjort om fra dato-tid, til kun dato.
Da gikk verdien for eksempel fra `10.01.2023 14:00` til `10.01.2023` og vi mistet i noen tilfeller noen timer.
Ordlyden kunne potensielt vært endra fra `til -> tilOgMed` den gangen, men slik ble det ikke.

Legger på description på felt i kontrakten for fengsling/restriksjon/isolasjon for å presisere at forventningen er at dommer bruker ordlyden "ikke utover dato" som i praksis betyr:

"Dommer bestemmer at siktede skal ilegges brev og besøksforbud, [så lenge som det er nødvendig], men ikke utover tirsdag 10.01.2023"

Altså at det opphører en eller annen gang i løpet av kontortiden tirsdag 10.01.2023, eller før om det kommer en oppdatering på det.

Dersom det er ulik praksis på dette rundt om, så er altså dette ny forventning om "standard" måte å ordlegge seg.
Ordlyden "..inntil dato" utgår, til fordel for "...ikke utover dato..".