### PR TITLE
Reorganisering rfc

### DIFF
--- a/kontrakter/politi/bestillvaretektsplass/changelog.md
+++ b/kontrakter/politi/bestillvaretektsplass/changelog.md
@@ -1,6 +1,9 @@
 # bestilling varetektsplass endringer
 Omorganisert slik at det er en katalog for hver melding og eksempelfiler på samme sted (forrige PR).
 
+### 08.01.2024 rydder i PR
+Se [readme.md](./readme.md) for endringer i PR som vi skal se på til neste versjon.
+
 ### 17.04.2023
 melding og forsendelse justeringer i hennhold til [begjaering varetekt](../varetekt/1.0/begjaeringVaretekt.schema.json)
 

--- a/kontrakter/politi/bestillvaretektsplass/readme.md
+++ b/kontrakter/politi/bestillvaretektsplass/readme.md
@@ -10,7 +10,18 @@ SchemaVersion=1.0
 
 [Se changelog for endringer](changelog.md)
 
+## Status
+Venter på avklaring fra styringsgrupp/Justisdepartementet, avslutter alle PR for å kunne omorganisere.
+
 ## Ønsker / mangler
+### Gammel PR #50 gjennomgang med Øivind Bjørløw
+branch feature/paagrepetsted-og-verge-full-person, sletter branch når vi har inkorporert endringer.
+
+- Pågrepet sted er vel viktigst. Er det vanskeligheter med å få med i ny løsning?
+- Kontaktopplysninger for advokater var foreslått inn. Etter modellen brukt i PeU, mener jeg huske.
+- Krimtype foreslått obligatorisk (men det kan vel utledes om det er vanskelig for dere).
+- Bedre/utvidede beskrivelser.
+- Mye av PR var et ekstra eksempel. Vi bør generelt bli bedre på flere og bedre eksempler, tenker jeg.
 ### Pågrepet kommune
 Pågrepet kommune brukes til NAV av Kriminalomsorgen fordi det er det lokale NAV kontoret i pågrepet kommune som har ansvaret ?
 

--- a/rfc/organisering.md
+++ b/rfc/organisering.md
@@ -1,0 +1,58 @@
+# Organisering av kontrakter
+
+**To be Reviewed By**: Alle
+
+**Authors**: Martin Myran
+
+**Status**: WIP
+
+## Problemstilling
+Dagens organisering basert på hvem som sender meldingen kan forbedres. Forslaget i koordineringsmøtene er å bruke en funksjonell oppdeling istedet.
+
+## Forslag til oppdeling
+Har laget en generell gruppe for kjennelser som skal fikse resten av kjennelsene f.eks. på tvangsmiddel. Hvis vi får behov for spesielle inndelinger så kan vi lage kjennelseTvangsmiddel på samme nivå.
+```
+└── kontrakter
+    ├── beslutninger (vet ikke helt, beslutning om at det blir ankebehandling, lukkede dører, ... )
+    │
+    ├── dom
+    │   ├── begjaeringDom (tilståelsessaker, meddomssaker eller vi må splitte)
+    │   ├── dom (eventuelt domTingrett, domLagmannsrett, domHoeyesterett hvis stor forskjeller)
+    │   ├── ankeDom (eventuelt en for lagmannsrett og en for Høyesterett)
+    │ 
+    ├── felles
+    │   ├── kodeverk
+    │   ├── kvittering
+    │   ├── siktelseTiltale
+    │
+    ├── konfliktraadet (kommer flere meldinger under her etter hvert)
+    │   ├── oppdatertSaksstatus
+    │   ├── overfoersakKonfliktraad
+    │
+    ├── kjennelser (generell inkl, andre tvangsmiddel.)
+    │   ├── begjaeringKjennelse
+    │   ├── kjennelse
+    │   ├── ankeKjennelse (kanskje brukes av både politi og domstol hvis siktede anker)
+    │
+    ├── personundersoekelse
+    │   ├── rekvisisjonPersonundersoekelse
+    │   ├── returPersonundersoekelse
+    │
+    ├── transport
+    │   ├── bestillTransport
+    │
+    ├── varetekt
+    │   ├── begjaeringVaretekt
+    │   ├── kjennelseVaretekt
+    │   ├── kjennelseVaretektPoliti
+    │   ├── bestillVaretektsplass
+    │   ├── tilbudVaretektsplass
+    │   ├── akseptTilbudtVaretektsplass
+    │   ├── avvisningTilbudtVaretektsplass
+    │   ├── innsettelsesordre
+    │
+    ├── personundersoekelse
+    │   ├── rekvisisjonPersonundersoekelse
+    │   ├── returPersonundersoekelse
+
+```

--- a/rfc/organisering.md
+++ b/rfc/organisering.md
@@ -9,7 +9,9 @@
 ## Problemstilling
 Dagens organisering basert på hvem som sender meldingen kan forbedres. Forslaget i koordineringsmøtene er å bruke en funksjonell oppdeling istedet.
 
-## Forslag til oppdeling
+Øverste nivå f.eks. kjennelser er for håndtering av alle kjennelser som ikke er varetekt, hvis det blir behov for mer spesifikke meldinger så kan det f.eks. lages en tvangsmiddel katalog med begjaering om kjennelse på tvangsmiddel og kjennelse på tvangsmiddel (som varetekt)
+
+## Forslag til oppdeling av dagens meldinger
 Har laget en generell gruppe for kjennelser som skal fikse resten av kjennelsene f.eks. på tvangsmiddel. Hvis vi får behov for spesielle inndelinger så kan vi lage kjennelseTvangsmiddel på samme nivå.
 ```
 └── kontrakter


### PR DESCRIPTION
Laget en RFC med forslag til reorganisering av dagens kontraker.
Den skal ikke holdes oppdatert når vi legger til nye kontrakter bare hvis vi endrer hvordan vi organiserer meldingene på.
Så vil slette bildet av selve organiseringen senere.