### PR TITLE
Forslag portert kontrakt løslatelsesordre (xml -> json)

### DIFF
--- a/kontrakter-forslag/varetekt/loslatelsesordre/arbeidsversjon/loslatelsesordre.schema.json
+++ b/kontrakter-forslag/varetekt/loslatelsesordre/arbeidsversjon/loslatelsesordre.schema.json
@@ -1,0 +1,878 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://politiet.no/varetekt/arbeidsversjon/loslatelsesordre.schema.json",
+  "description": "Schema definisjon av en Løslatelsesordre",
+  "type": "object",
+  "properties": {
+    "forsendelse": {
+      "description": "Avsender og mottaker",
+      "$ref": "#/definitions/forsendelse"
+    },
+    "saksInformasjon": {
+      "$ref": "#/definitions/saksInformasjon"
+    },
+    "kontaktpersoner": {
+      "type": "object",
+      "properties": {
+        "paataleansvarlig": {
+          "description": "Eksempel: ansvarlig politijurist",
+          "$ref": "#/definitions/ansattPerson"
+        }
+      },
+      "required": ["paataleansvarlig"],
+      "additionalProperties": false
+    },
+    "siktet": {
+      "description": "Person som skal løslates.",
+      "$ref": "#/definitions/siktetPerson"
+    },
+    "beslutning": {
+      "description": "Beslutning tatt av jurist.",
+      "$ref": "#/definitions/beslutning"
+    },
+    "andreRelevanteOpplysninger": {
+      "description": "Andre opplysninger som er relevante for løslatelsen. F.eks om personen er ilag forbudssoner og skal ha påsatt OVA før løslatelse.",
+      "type": "string"
+    },
+    "dokumenter": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/dokument"
+      }
+    }
+  },
+  "required": [
+    "forsendelse",
+    "kontaktpersoner",
+    "siktet",
+    "beslutning",
+    "dokumenter"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "saksInformasjon": {
+      "type": "object",
+      "properties": {
+        "domstolSaksnummer": {
+          "description": "Domstolen sitt interne saksnummer",
+          "type": "string"
+        },
+        "hovedstraffesaksnummer": {
+          "description": "Politiet sitt interne hovedstraffesaksnummer",
+          "$ref": "#/definitions/straffesaksnummer"
+        },
+        "kravId": {
+          "description": "Unik id for denne ordren.",
+          "$ref": "#/definitions/unikId"
+        },
+        "varetektSyklusId": {
+          "$ref": "#/definitions/unikId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "beslutning": {
+      "description": "Beslutning tatt av jurist",
+      "type": "object",
+      "properties": {
+        "grunn": {
+          "description": "Forskjellige typer (overføring til soning, løslatelse osv).",
+          "type": "string"
+        },
+        "besluttetAv": {
+          "description": "Jurist som besluttet.",
+          "$ref": "#/definitions/ansattPerson"
+        },
+        "tidspunkt": {
+          "description": "Tidspunkt for beslutning.",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "siktetPerson": {
+      "description": "Person med alle nyttige data som fødselsnummer adresse osv., SSP nummer kun på siktede, tiltalte.",
+      "type": "object",
+      "properties": {
+        "personForetakRef": {
+          "description": "Unik id kun lokalt i en melding, samme person kun i denne meldingen vil ha samme personForetakRef.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": {
+          "type": "string",
+          "format": "date"
+        },
+        "kjoenn": {
+          "description": "Ukjent kjønn hvis denne ikke er med",
+          "$ref": "#/definitions/kjoenn"
+        },
+        "statsborgerskap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/land"
+          }
+        },
+        "identitetsnummer": {
+          "description": "Fødselsnummer, D-nummer eller SSP nummer som er i bruk. Siktede vil alltid ha med denne.",
+          "$ref": "#/definitions/personIdentifikator"
+        },
+        "tilleggsId": {
+          "description": "Kan være SSP nummer hvis person har D-nummer, fremtidig historiske nummer?",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personIdentifikator"
+          }
+        },
+        "adresseGradering": {
+          "description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå",
+          "$ref": "#/definitions/adresseGradering"
+        },
+        "personAdresse": {
+          "$ref": "#/definitions/personAdresse"
+        }
+      },
+      "required": [
+        "personForetakRef",
+        "navn",
+        "foedselsdato",
+        "statsborgerskap",
+        "identitetsnummer",
+        "tilleggsId"
+      ],
+      "additionalProperties": false
+    },
+    "saksInformasjon": {
+      "type": "object",
+      "properties": {
+        "hovedstraffesaksnummer": {
+          "description": "Politiet sitt interne hovedstraffesaksnummer",
+          "$ref": "#/definitions/straffesaksnummer"
+        }
+      },
+      "additionalProperties": false
+    },
+    "person": {
+      "description": "Person som ikke er siktet eller tiltalt, vil aldri ha SSP nummer",
+      "type": "object",
+      "properties": {
+        "personForetakRef": {
+          "description": "Unik id kun lokalt i en melding, samme person kun i denne meldingen vil ha samme personForetakRef.",
+          "$ref": "#/definitions/GUID"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": {
+          "type": "string",
+          "format": "date"
+        },
+        "kjoenn": {
+          "description": "Ukjent kjønn hvis denne ikke er med",
+          "$ref": "#/definitions/kjoenn"
+        },
+        "statsborgerskap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/land"
+          }
+        },
+        "identitetsnummer": {
+          "description": "Fødselsnummer eller D-nummer.",
+          "$ref": "#/definitions/personIdentifikator"
+        },
+        "tilleggsId": {
+          "description": "D-nummer, tidligere fødselsnummer ?",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personIdentifikator"
+          }
+        },
+        "adresseGradering": {
+          "description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå",
+          "$ref": "#/definitions/adresseGradering"
+        },
+        "personAdresse": {
+          "$ref": "#/definitions/personAdresse"
+        }
+      },
+      "required": [
+        "personForetakRef",
+        "navn",
+        "foedselsdato",
+        "statsborgerskap",
+        "tilleggsId"
+      ],
+      "additionalProperties": false
+    },
+    "adresseGradering": {
+      "description": "Samme enum som folkeregisteret, ugradert hvis den ikke er gradert",
+      "type": "string",
+      "enum": ["KLIENT_ADRESSE", "FORTROLIG", "STRENGT_FORTROLIG"]
+    },
+    "personAdresse": {
+      "description": "Kan være graderte adresser",
+      "type": "object",
+      "properties": {
+        "gradering": {
+          "description": "Vi sender ikke med graderte adresser bortsett fra kanskje KLIENT_ADRESSE (sjekker)",
+          "$ref": "#/definitions/adresseGradering"
+        },
+        "adresse": {
+          "$ref": "#/definitions/adresse"
+        }
+      },
+      "required": ["adresse"],
+      "additionalProperties": false
+    },
+    "adresse": {
+      "description": "Norsk eller utenlandsk adresse",
+      "type": "object",
+      "properties": {
+        "norge": {
+          "description": "Norsk adresse",
+          "$ref": "#/definitions/adresseNorge"
+        },
+        "utland": {
+          "$ref": "#/definitions/adresseUtland"
+        }
+      },
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "norge": {
+              "$ref": "#/definitions/adresseNorge"
+            }
+          },
+          "required": ["norge"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "utland": {
+              "$ref": "#/definitions/adresseUtland"
+            }
+          },
+          "required": ["utland"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "adresseNorge": {
+      "description": "Norske med litt strengere validering på postnummer",
+      "type": "object",
+      "properties": {
+        "adresselinjer": {
+          "type": "array",
+          "maxItems": 4,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          }
+        },
+        "postnummer": {
+          "$ref": "#/definitions/norskPostnummer"
+        },
+        "poststed": {
+          "type": "string"
+        }
+      },
+      "required": ["adresselinjer", "postnummer"],
+      "additionalProperties": false
+    },
+    "adresseUtland": {
+      "type": "object",
+      "properties": {
+        "adresselinjer": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 4,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          }
+        },
+        "postnummer": {
+          "type": "string"
+        },
+        "poststed": {
+          "type": "string"
+        },
+        "land": {
+          "$ref": "#/definitions/land"
+        }
+      },
+      "required": ["adresselinjer"],
+      "additionalProperties": false
+    },
+    "personnavn": {
+      "type": "object",
+      "properties": {
+        "fornavn": {
+          "type": "string"
+        },
+        "mellomnavn": {
+          "type": "string"
+        },
+        "etternavn": {
+          "type": "string"
+        }
+      },
+      "required": ["fornavn", "etternavn"],
+      "additionalProperties": false
+    },
+    "forsendelse": {
+      "type": "object",
+      "properties": {
+        "meldingsId": {
+          "$ref": "#/definitions/GUID"
+        },
+        "sendtTid": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "avsender": {
+          "$ref": "#/definitions/avsender"
+        },
+        "mottaker": {
+          "$ref": "#/definitions/mottaker"
+        }
+      },
+      "required": ["meldingsId", "sendtTid", "avsender", "mottaker"],
+      "additionalProperties": false
+    },
+    "avsender": {
+      "type": "object",
+      "properties": {
+        "organisasjon": {
+          "description": "Entydig identifikator av juridisk enhet. F.eks et spesifikt domstol embete eller politidistrikt",
+          "$ref": "#/definitions/organisasjon"
+        },
+        "person": {
+          "description": "Person som sender meldingen. ",
+          "$ref": "#/definitions/ansattPerson"
+        }
+      },
+      "required": ["organisasjon"],
+      "additionalProperties": false
+    },
+    "mottaker": {
+      "type": "object",
+      "properties": {
+        "organisasjon": {
+          "$ref": "#/definitions/organisasjon"
+        }
+      },
+      "required": ["organisasjon"],
+      "additionalProperties": false
+    },
+    "organisasjon": {
+      "description": "Entydig identifikator av juridisk enhet. F.eks et spesifikt domstol embete eller politidistrikt",
+      "type": "object",
+      "properties": {
+        "navn": {
+          "description": "F.eks. Nordland politidistrikt eller Oslo tingrett.",
+          "type": "string"
+        },
+        "organisasjonsnummer": {
+          "$ref": "#/definitions/organisasjonsnummer"
+        }
+      },
+      "required": ["organisasjonsnummer"],
+      "additionalProperties": false
+    },
+    "dokument": {
+      "description": "Et dokument har en ID for at det skal kunne refereres til fra andre steder.",
+      "type": "object",
+      "properties": {
+        "internId": {
+          "description": "Referanse/journal nummer fra BL, Lovisa eller KODA/Kompis",
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 50
+        },
+        "forsendelse": {
+          "$ref": "#/definitions/dokumentforsendelse"
+        },
+        "overskrift": {
+          "description": "Klippe på slutten hvis det er for langt",
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 260
+        },
+        "skrevetDato": {
+          "$ref": "#/definitions/dato"
+        },
+        "kategori": {
+          "$ref": "#/definitions/kodeverk"
+        }
+      },
+      "required": ["internId", "forsendelse", "overskrift", "kategori"],
+      "additionalProperties": false
+    },
+    "dokumentforsendelse": {
+      "description": "Detaljer om lokasjon og type",
+      "type": "object",
+      "properties": {
+        "mimeType": {
+          "type": "string"
+        },
+        "sjekksum": {
+          "description": "Sjekksum av dokumentet basert på md5sum algoritmen.",
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "required": ["mimeType", "sjekksum", "uri"],
+      "additionalProperties": false
+    },
+    "ansattPerson": {
+      "description": "Type for personer som er ansatt hos påtale eller domstolen(saksbehandlere, påtaleadvokater, statsadvokater,...)",
+      "type": "object",
+      "properties": {
+        "etternavn": {
+          "type": "string"
+        },
+        "fornavn": {
+          "type": "string"
+        },
+        "tittel": {
+          "type": "string"
+        },
+        "kontakt": {
+          "$ref": "#/definitions/kontaktInfoPerson"
+        }
+      },
+      "required": ["etternavn", "fornavn", "tittel", "kontakt"],
+      "additionalProperties": false
+    },
+    "personForetak": {
+      "description": "Person i personliste eller et foretak i foretaklisten",
+      "type": "object",
+      "properties": {
+        "person": {
+          "$ref": "#/definitions/privatPerson"
+        },
+        "foretak": {
+          "$ref": "#/definitions/foretak"
+        }
+      },
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "person": {
+              "$ref": "#/definitions/privatPerson"
+            }
+          },
+          "required": ["person"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "foretak": {
+              "$ref": "#/definitions/foretak"
+            }
+          },
+          "required": ["foretak"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "personForetakRef": {
+      "description": "Refererer til en person i personliste eller et foretak i foretaklisten",
+      "type": "object",
+      "properties": {
+        "personRef": {
+          "$ref": "#/definitions/personRef"
+        }
+      },
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "personRef": {
+              "$ref": "#/definitions/personRef"
+            }
+          },
+          "required": ["personRef"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "foretakRef": {
+              "$ref": "#/definitions/foretakRef"
+            }
+          },
+          "required": ["foretakRef"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "personRef": {
+      "description": "Referanse inn i siktedeTiltaltePersonerForetak",
+      "$ref": "#/definitions/internId"
+    },
+    "foretakRef": {
+      "description": "Referanse inn i siktedeTiltaltePersonerForetak",
+      "$ref": "#/definitions/internId"
+    },
+    "privatPerson": {
+      "description": "Den domfelte som skal ha sin dom fullbyrdet",
+      "type": "object",
+      "properties": {
+        "internId": {
+          "description": "Intern id i melding, samme person i denne meldingen vil ha samme internId",
+          "$ref": "#/definitions/internId"
+        },
+        "etternavn": {
+          "type": "string"
+        },
+        "fornavn": {
+          "type": "string"
+        },
+        "identitetsnummer": {
+          "description": "Fødselsnummer, D-nummer eller SSP nummer. Alle personer som det er foretatt tvangsmidler mot skal ha et D-nummer eller fødselsnummer. Dersom politiet ikke har et slikt nummer vil de generere ett 'SSP nummer'",
+          "$ref": "#/definitions/personIdentifikator"
+        },
+        "tilleggsId": {
+          "description": "Kan f.eks. være historiske SSP nummer. ",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personIdentifikator"
+          }
+        },
+        "foedselsdato": {
+          "description": ".",
+          "$ref": "#/definitions/dato"
+        },
+        "kjoenn": {
+          "$ref": "#/definitions/kjoenn"
+        },
+        "statsborgerskap": {
+          "description": "Tom array dersom statsborgerskap er ukjennt",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/land"
+          }
+        }
+      },
+      "required": [
+        "internId",
+        "etternavn",
+        "identitetsnummer",
+        "tilleggsId",
+        "statsborgerskap"
+      ],
+      "additionalProperties": false
+    },
+    "foretak": {
+      "description": "Foretak/ organisasjon som er med i en straffesak som f.eks. siktet",
+      "$comment": "Bør vi ha med 'adresse' her? (politiet har det i begjæring). Kan også vurdere å slå denne sammen med organisasjon",
+      "type": "object",
+      "properties": {
+        "internId": {
+          "ref": "#/definitions/internId",
+          "description": "Unik id lokalt i meldingen, samme internId er samme foretak."
+        },
+        "organisasjonsnummer": {
+          "$ref": "#/definitions/organisasjonsnummer"
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["internId", "navn"],
+      "additionalProperties": false
+    },
+    "rettsmoete": {
+      "type": "object",
+      "properties": {
+        "rettsmoeteTidFra": {
+          "$ref": "#/definitions/datoTid"
+        },
+        "rettsmoeteTidTil": {
+          "$ref": "#/definitions/datoTid"
+        }
+      },
+      "additionalProperties": false
+    },
+    "varighet": {
+      "description": "Definisjon på en varighet. F.eks. varighet på en betinget fengselsstraff",
+      "type": "object",
+      "properties": {
+        "lengde": {
+          "$ref": "#/definitions/lengde"
+        },
+        "ubestemtTid": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "lengde": {
+              "$ref": "#/definitions/lengde"
+            }
+          },
+          "required": ["lengde"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ubestemtTid": {
+              "type": "boolean"
+            }
+          },
+          "required": ["ubestemtTid"]
+        }
+      ]
+    },
+    "lengde": {
+      "type": "object",
+      "properties": {
+        "antallAar": {
+          "type": "integer"
+        },
+        "antallMaaneder": {
+          "type": "integer"
+        },
+        "antallDager": {
+          "type": "integer"
+        },
+        "antallTimer": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false
+    },
+    "periode": {
+      "type": "object",
+      "properties": {
+        "TidFra": {
+          "$ref": "#/definitions/datoTid"
+        },
+        "tidTil": {
+          "$ref": "#/definitions/datoTid"
+        }
+      },
+      "additionalProperties": false
+    },
+    "kontaktInfoPerson": {
+      "description": "Epost og/eller telefonnummer/mobil",
+      "type": "object",
+      "properties": {
+        "epost": {
+          "$ref": "#/definitions/epost"
+        },
+        "telefonnummer": {
+          "$ref": "#/definitions/telefonnummer"
+        }
+      },
+      "additionalProperties": false
+    },
+    "land": {
+      "description": "En landkode består av tre store bokstaver fra kodelisten ISO 3166-1-alpha-3. Hentes fra kodeverk nationality.xml",
+      "type": "object",
+      "properties": {
+        "kode": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 3,
+          "pattern": "^[A-Z]+$"
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["kode", "navn"],
+      "additionalProperties": false
+    },
+    "personIdentifikator": {
+      "description": "Fødselsnummer, D-nummer eller SSP nummer.",
+      "type": "object",
+      "properties": {
+        "foedselsnummer": {
+          "$ref": "#/definitions/foedselsnummer"
+        },
+        "sspNummer": {
+          "$ref": "#/definitions/sspNummer"
+        },
+        "dNummer": {
+          "$ref": "#/definitions/dNummer"
+        }
+      },
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "foedselsnummer": {
+              "description": "Kun norsk fødselsnummer. Hvis det er et D-nummer så kommer det i eget felt.",
+              "$ref": "#/definitions/foedselsnummer"
+            }
+          },
+          "required": ["foedselsnummer"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "sspNummer": {
+              "$ref": "#/definitions/sspNummer"
+            }
+          },
+          "required": ["sspNummer"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "dNummer": {
+              "$ref": "#/definitions/dNummer"
+            }
+          },
+          "required": ["dNummer"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "saervilkaar": {
+      "type": "object",
+      "properties": {
+        "paragraf": {
+          "description": "Eks. '§37'",
+          "type": "string"
+        },
+        "tekst": {
+          "description": "Eks. Andre særvilkår'",
+          "type": "string"
+        },
+        "detaljer": {
+          "description": "Detaljer for særvilkåret. Fylles ut ved '§ 37.Andre særvilkår'",
+          "type": "string"
+        },
+        "beskrivelse": {
+          "description": "Brukerens egen beskrivelse av særvilkåret",
+          "type": "string"
+        }
+      },
+      "required": ["paragraf", "tekst"],
+      "additionalProperties": false
+    },
+    "basissakResultatType": {
+      "description": "Resultatet av basissaken. 'FRAFALT' betyr at punktet tas ut av siktelsen/tiltalen",
+      "type": "string",
+      "enum": ["SKYLDIG", "FRIKJENT", "FRAFALT"]
+    },
+    "kjoenn": {
+      "description": "Samme enum som folkeregisteret",
+      "type": "string",
+      "enum": ["KVINNE", "MANN"]
+    },
+    "rettsInstansType": {
+      "type": "string",
+      "enum": ["TINGRETT", "LAGMANNSRETT", "HOEYESTERETT"]
+    },
+    "internId": {
+      "description": "id, unik innenfor melding",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 40
+    },
+    "unikId": {
+      "type": "object"
+    },
+    "organisasjonsnummer": {
+      "description": "Norsk organisasjonsnummer fra BRREG. Referanse til politistrikt, domstol, fengsel. https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/organisasjonsnummeret/",
+      "type": "string",
+      "minLength": 9,
+      "maxLength": 9,
+      "pattern": "^[0-9]+$"
+    },
+    "foedselsnummer": {
+      "type": "string",
+      "minLength": 11,
+      "maxLength": 11,
+      "pattern": "^[0-3][0-9][0189][0-9]+$"
+    },
+    "sspNummer": {
+      "type": "string",
+      "minLength": 11,
+      "maxLength": 11,
+      "pattern": "^[0-3][0-9][2-3][0-9]+$"
+    },
+    "dNummer": {
+      "type": "string",
+      "minLength": 11,
+      "maxLength": 11,
+      "pattern": "^[4-7][0-9][0189][0-9]+$"
+    },
+    "kodeverk": {
+      "type": "object",
+      "properties": {
+        "kode": {
+          "type": "string"
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["kode"],
+      "additionalProperties": false
+    },
+    "straffesaksnummer": {
+      "description": "Som regel et løpenummer, men kan i fremtiden også inneholde bokstaver",
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 30
+    },
+    "epost": {
+      "description": "Patternet sørger for at det ikke er mellomrom, kun en '@' og alltid kun èn '.' i domene",
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 150,
+      "pattern": "^[^\\s@]+@([^\\s@.,]+\\.)+[^\\s@.,]{2,}$"
+    },
+    "telefonnummer": {
+      "description": "Ett telefonnummer, norsk eller utenlands, med eller uten land prefix. Tillater +før landkode, - tegn, space og paranteser.",
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 30,
+      "pattern": "^\\+?[0-9, ,\\-,\\(,)]*$"
+    },
+    "datoTid": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "dato": {
+      "type": "string",
+      "format": "date"
+    },
+    "norskPostnummer": {
+      "description": "Norsk postnummer er i dag 4 siffer",
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 4,
+      "pattern": "^[0-9]+$"
+    },
+    "GUID": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    }
+  }
+}

--- a/kontrakter-forslag/varetekt/loslatelsesordre/changelog.md
+++ b/kontrakter-forslag/varetekt/loslatelsesordre/changelog.md
@@ -1,3 +1,3 @@
 # changelog
 
-- Førsteutkast
+- Førsteutkast. Ren port fra https://github.com/domstolene/ESAS/blob/main/kontrakter-xsd/fengsling/1.0/loeslatelsesordre.xsd . Mangler kodeverdier for beslutning grunn. Mangler "andre aktører" (?) liste.

--- a/kontrakter-forslag/varetekt/loslatelsesordre/changelog.md
+++ b/kontrakter-forslag/varetekt/loslatelsesordre/changelog.md
@@ -1,0 +1,3 @@
+# changelog
+
+- Førsteutkast

--- a/kontrakter-forslag/varetekt/loslatelsesordre/readme.md
+++ b/kontrakter-forslag/varetekt/loslatelsesordre/readme.md
@@ -1,0 +1,11 @@
+# Løslatelsesordre
+Versjon 1.0 er første versjon som vi skal i produksjon med.
+* [JSON Schema](1.0/loslatelsesordre.schema.json)
+* [Eksempler](1.0/eksempelfiler/)
+
+## Headere forsendelse justisHub
+SchemaName=LOSLATELSESORDRE  
+SchemaVersion=1.0
+[RFC](../../../rfc/MessageName-header.md)
+
+[Se changelog for endringer](changelog.md)

--- a/validateJsonSchema.js
+++ b/validateJsonSchema.js
@@ -17,7 +17,8 @@ const jsonSchemaFolders = [
   "kontrakter/konfliktraadet/oppdatertsaksstatus",
   "kontrakter/personundersoekelse/rekvisisjonPersonundersoekelse",
   "kontrakter/personundersoekelse/returPersonundersoekelse",
-  "kontrakter/siktelseTiltale"
+  "kontrakter/siktelseTiltale",
+  "kontrakter-forslag/varetekt/loslatelsesordre"
 ];
 
 const jsonKodeverkFolders = ["kodeverk/felles", "kodeverk/konfliktraad"];


### PR DESCRIPTION
Heiv opp et grovt forslag til en port fra xml -> json for kontrakt løslatelsesordre.

Mangler noen elementer fra ESAS2020 BL xml melding, men det kan justeres om det her skal leveres etter hvert. 
F.eks Beslutning grunn  kodeverk  og liste over "andre aktører". 