### PR TITLE
Samtykke til deling i koordineringsgruppen er optional

### DIFF
--- a/kontrakter/personundersoekelse/rekvisisjonPersonundersoekelse/1.0/rekvisisjonPersonundersoekelse.schema.json
+++ b/kontrakter/personundersoekelse/rekvisisjonPersonundersoekelse/1.0/rekvisisjonPersonundersoekelse.schema.json
@@ -194,8 +194,7 @@
       },
       "required": [
         "informertOmAnmodningOmPersonundersoekelse",
-        "samtykketTilPersonundersoekelse",
-        "samtykketTilDelingAvOpplysningerIKoordineringsgruppen"
+        "samtykketTilPersonundersoekelse"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
Etter diskusjoner så er propertien "samtykketTilDelingAvOpplysningerIKoordineringsgruppen" nå optional.