### PR TITLE
Fjernet fre Fransk som er ISO-639-2 kode

### DIFF
--- a/kodeverk/felles/spraakkategori.json
+++ b/kodeverk/felles/spraakkategori.json
@@ -99,10 +99,6 @@
     },
     {
       "beskrivelse": "Fransk",
-      "kode": "FRE"
-    },
-    {
-      "beskrivelse": "Fransk",
       "kode": "FRA"
     },
     {


### PR DESCRIPTION
Fra det vi kan skjønne så er det kommet med noe fra ISO-639-2 kode for fransk så vi har duplikat.