### PR TITLE
Vegtrafikkulykke endringer

### DIFF
--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/eksempelfiler/trafikkulykke-eksempel-1.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/eksempelfiler/trafikkulykke-eksempel-1.json
@@ -8,9 +8,13 @@
         "navn": "Innlandet politidistrikt"
       },
       "person": {
-        "etternavn": "Testesen",
+        "navn": {
+          "fornavn": "Test",
+          "etternavn": "Testesen"
+        },
         "kontakt": {
-          "telefonnummer": ["12 34 56 78"]
+          "telefonnummer": "12 34 56 78",
+          "epost": "test.testesen@politiet.no"
         }
       }
     },

--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/eksempelfiler/trafikkulykke-eksempel-1.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/eksempelfiler/trafikkulykke-eksempel-1.json
@@ -12,7 +12,7 @@
           "fornavn": "Test",
           "etternavn": "Testesen"
         },
-        "kontakt": {
+        "kontaktinfo": {
           "telefonnummer": "12 34 56 78",
           "epost": "test.testesen@politiet.no"
         }

--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/eksempelfiler/trafikkulykke-eksempel-1.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/eksempelfiler/trafikkulykke-eksempel-1.json
@@ -71,7 +71,6 @@
     ],
     "involverteEnheter": [
       {
-        "id": "enhet_1",
         "enhetsbokstav": "A",
         "registreringsnummer": "AB123456789",
         "enhetstype": "PERSONBIL_STASJONSVOGN",

--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
@@ -648,7 +648,12 @@
           "description": "Informasjon om person involvert i ulykken."
         }
       },
-      "required": ["enhetsbokstav", "registreringsnummer", "enhetstype", "personer"],
+      "required": [
+        "enhetsbokstav",
+        "registreringsnummer",
+        "enhetstype",
+        "personer"
+      ],
       "additionalProperties": false
     },
     "plasseringKjoeretoey": {

--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
@@ -900,15 +900,25 @@
     },
     "ansattPerson": {
       "type": "object",
-      "description": "Saksbehandler hos politiet.",
+      "description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
       "properties": {
-        "brukeridentifikasjon": {
-          "type": "string",
-          "description": "Id som ikke endrer seg, vil være BID hos politiet til å begynne med, men vil endres"
-        },
         "tittel": {
           "type": "string"
         },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "kontakt": {
+          "$ref": "#/definitions/kontaktInfoPerson",
+          "description": "Minimum epost adresse til den som sender melding."
+        }
+      },
+      "required": ["navn", "kontakt"],
+      "additionalProperties": false
+    },
+    "personnavn": {
+      "type": "object",
+      "properties": {
         "fornavn": {
           "type": "string"
         },
@@ -917,28 +927,21 @@
         },
         "etternavn": {
           "type": "string"
-        },
-        "kontakt": {
-          "$ref": "#/definitions/kontaktInfo",
-          "description": "Kontaktinformasjon på forsendelsen."
         }
       },
-      "required": ["etternavn", "kontakt"],
+      "required": ["fornavn", "etternavn"],
       "additionalProperties": false
     },
-    "kontaktInfo": {
+    "kontaktInfoPerson": {
       "type": "object",
+      "description": "Alle har epost adresse, men kanskje ikke registrert mobil/telefon",
       "properties": {
         "epost": {
-          "type": "string",
-          "format": "email"
+          "$ref": "#/definitions/epost"
         },
-        "telefonnummer": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/telefonnummer" }
-        }
+        "telefonnummer": { "$ref": "#/definitions/telefonnummer" }
       },
-      "required": ["telefonnummer"],
+      "required": ["epost"],
       "additionalProperties": false
     },
     "organisasjonsnummer": {
@@ -953,6 +956,10 @@
       "description": "Telefonnummer, norsk eller utenlandsk, med eller uten landkode/prefix",
       "maxLength": 30,
       "minLength": 1
+    },
+    "epost": {
+      "type": "string",
+      "format": "email"
     }
   }
 }

--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
@@ -427,10 +427,6 @@
       "type": "object",
       "description": "Informasjon om kjøretøy",
       "properties": {
-        "id": {
-          "type": "string",
-          "description": "Gjør enheten unikt identifiserbar innad i saken, må være lik ved oppdateringsmelding."
-        },
         "enhetsbokstav": {
           "type": "string",
           "description": "Enheten sin ID i saken. A, B, C...."

--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
@@ -648,12 +648,7 @@
           "description": "Informasjon om person involvert i ulykken."
         }
       },
-      "required": [
-        "enhetsbokstav",
-        "registreringsnummer",
-        "enhetstype",
-        "personer"
-      ],
+      "required": ["enhetsbokstav", "enhetstype", "personer"],
       "additionalProperties": false
     },
     "plasseringKjoeretoey": {

--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
@@ -648,7 +648,7 @@
           "description": "Informasjon om person involvert i ulykken."
         }
       },
-      "required": ["id"],
+      "required": ["enhetsbokstav", "registreringsnummer", "enhetstype", "personer"],
       "additionalProperties": false
     },
     "plasseringKjoeretoey": {

--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
@@ -769,7 +769,7 @@
         "kryssendeVeg": { "$ref": "#/definitions/vegInformasjon" },
         "koordinater": { "$ref": "#/definitions/koordinater" }
       },
-      "required": ["veg", "kryssendeVeg"],
+      "required": ["veg"],
       "additionalProperties": false
     },
     "vegInformasjon": {

--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
@@ -896,7 +896,7 @@
     },
     "ansattPerson": {
       "type": "object",
-      "description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
+      "description": "Saksbehandler, jurist, etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
       "properties": {
         "tittel": {
           "type": "string"
@@ -904,12 +904,12 @@
         "navn": {
           "$ref": "#/definitions/personnavn"
         },
-        "kontakt": {
+        "kontaktinfo": {
           "$ref": "#/definitions/kontaktInfoPerson",
           "description": "Minimum epost adresse til den som sender melding."
         }
       },
-      "required": ["navn", "kontakt"],
+      "required": ["navn", "kontaktinfo"],
       "additionalProperties": false
     },
     "personnavn": {


### PR DESCRIPTION
- Gjør `kryssendeVeg` nullable
- Strukturelle endringer rundt `ansattPerson`
  - Fjerner også ansattPerson sin `brukeridentifikasjon`, da Politiet helst ikke ønsker å dele denne
 - Foreslår å fjerne involvertEnhet sin`id`. Denne eksisterer ikke i dag i BL, og kontrakten definerer allerede `enhetsbokstav`. BL kan legge til `id` for en enhet i en sak, men det er ikke sikkert at denne vil være mer riktig enn det `enhetsbokstav` vil være.