### PR TITLE
Siktelse tiltale synkroniser typer med bestilling av varetekt og fullbyrdelsesordre

### DIFF
--- a/kontrakter/siktelseTiltale/1.0/eksempelfiler/siktelseTiltale-eksempel-1.json
+++ b/kontrakter/siktelseTiltale/1.0/eksempelfiler/siktelseTiltale-eksempel-1.json
@@ -23,7 +23,7 @@
     }
   },
   "hovedStraffesaksnummer": "15439560",
-  "begjaeringAnmodning": {
+  "begjaeringAnmodningReferanse": {
     "kravId": "E33B9049-34B7-4D31-92A7-4D7CB478B538"
   },
   "siktelseTiltale": {
@@ -33,7 +33,6 @@
       {
         "nummer": "I",
         "prinsipalLovbud": {
-          "lovbudKombinertId": "6236FDDC-213D-4A2F-BAAA-4FD75AFA9DF7",
           "lovbud": [
             {
               "lovbudId": "A1D0F6A9-D4C1-4F2D-A69E-039ACB090304",
@@ -90,7 +89,8 @@
         "etternavn": "FABRIKKPIPE"
       },
       "identitetsnummer": {
-        "foedselsnummer": "22918197870"
+        "idType": "FOEDSELSNUMMER",
+        "verdi": "22918197870"
       },
       "tilleggsId": [],
       "kjoenn": "KVINNE",
@@ -100,16 +100,7 @@
           "kode": "NOR",
           "navn": "Norge"
         }
-      ],
-      "personAdresse": {
-        "adresse": {
-          "norge": {
-            "adresselinjer": ["Pampusvegen 32"],
-            "postnummer": "6285",
-            "poststed": "STOREKALVØY"
-          }
-        }
-      }
+      ]
     }
   ],
   "siktedeForetak": [],
@@ -121,9 +112,9 @@
         "etternavn": "HARE"
       },
       "identitetsnummer": {
-        "foedselsnummer": "25835799770"
+        "idType": "FOEDSELSNUMMER",
+        "verdi": "25835799770"
       },
-      "tilleggsId": [],
       "kjoenn": "MANN",
       "foedselsdato": "1957-03-25",
       "statsborgerskap": [
@@ -131,16 +122,7 @@
           "kode": "NOR",
           "navn": "Norge"
         }
-      ],
-      "personAdresse": {
-        "adresse": {
-          "norge": {
-            "adresselinjer": ["Olsbryggevegen 34"],
-            "postnummer": "3830",
-            "poststed": "ULEFOSS"
-          }
-        }
-      }
+      ]
     },
     {
       "personForetakRef": "922E9192-CBB8-4A32-B2CC-CA7B3498D484",
@@ -149,9 +131,9 @@
         "etternavn": "POSTKASSE"
       },
       "identitetsnummer": {
-        "foedselsnummer": "15858796374"
+        "idType": "FOEDSELSNUMMER",
+        "verdi": "15858796374"
       },
-      "tilleggsId": [],
       "kjoenn": "MANN",
       "foedselsdato": "1987-05-15",
       "statsborgerskap": [
@@ -159,16 +141,7 @@
           "kode": "NOR",
           "navn": "Norge"
         }
-      ],
-      "personAdresse": {
-        "adresse": {
-          "norge": {
-            "adresselinjer": ["Galterudstubben 9"],
-            "postnummer": "2614",
-            "poststed": "LILLEHAMMER"
-          }
-        }
-      }
+      ]
     }
   ],
   "fornaermedeForetak": [],
@@ -180,10 +153,11 @@
           "gjerningstidspunktFra": "2023-05-01T00:00:00+01:00",
           "gjerningstidspunktTil": "2023-05-01T00:00:00+01:00",
           "gjerningssted": {
-            "norge": {
+            "adresse": {
               "adresselinjer": ["Gartneriveien 2"],
               "postnummer": "3770",
-              "poststed": "KRAGERØ"
+              "poststed": "KRAGERØ",
+              "land": { "kode": "NOR", "navn": "Norge" }
             }
           }
         },
@@ -201,10 +175,11 @@
           "gjerningstidspunktFra": "2023-07-01T00:00:00+01:00",
           "gjerningstidspunktTil": "2023-07-01T00:00:00+01:00",
           "gjerningssted": {
-            "norge": {
+            "adresse": {
               "adresselinjer": ["Weiss gate 5D"],
               "postnummer": "3611",
-              "poststed": "KONGSBERG"
+              "poststed": "KONGSBERG",
+              "land": { "kode": "NOR", "navn": "Norge" }
             }
           }
         },

--- a/kontrakter/siktelseTiltale/1.0/eksempelfiler/siktelseTiltale-eksempel-2.json
+++ b/kontrakter/siktelseTiltale/1.0/eksempelfiler/siktelseTiltale-eksempel-2.json
@@ -23,7 +23,7 @@
     }
   },
   "hovedStraffesaksnummer": "15434059",
-  "begjaeringAnmodning": {
+  "begjaeringAnmodningReferanse": {
     "kravId": "CB00588D-6C04-4A63-B587-438605DF5D6F"
   },
   "siktelseTiltale": {
@@ -33,7 +33,6 @@
       {
         "nummer": "I",
         "prinsipalLovbud": {
-          "lovbudKombinertId": "D57EFE89-6C8C-489E-A92E-5E9CC7261CF4",
           "lovbud": [
             {
               "lovbudId": "1713FA29-57D6-7F97-E053-0B3EA30AAE0D",
@@ -62,7 +61,6 @@
       {
         "nummer": "II",
         "prinsipalLovbud": {
-          "lovbudKombinertId": "E4AC5E62-7047-4213-8A27-AA4D8333614B",
           "lovbud": [
             {
               "lovbudId": "EE57A116-D7B4-4F5B-99DB-F4D52FA75F06",
@@ -95,7 +93,6 @@
       {
         "nummer": "III",
         "prinsipalLovbud": {
-          "lovbudKombinertId": "165AB44B-701C-4E11-BB0F-8ED21BC2AE82",
           "lovbud": [
             {
               "lovbudId": "1713FA29-5638-7F97-E053-0B3EA30AAE0D",
@@ -124,7 +121,6 @@
       {
         "nummer": "IV",
         "prinsipalLovbud": {
-          "lovbudKombinertId": "433E8CD6-1B06-4C65-BD56-D98464AAC13C",
           "lovbud": [
             {
               "lovbudId": "FA8DEA3F-7462-450F-9413-BC3A697F2DDA",
@@ -142,7 +138,6 @@
             },
             "subsidiaerLovbudGrunnlag": {
               "subsidiaerLovbud": {
-                "lovbudKombinertId": "A713BBFB-3457-480A-B21E-B393914B4BBB",
                 "lovbud": [
                   {
                     "lovbudId": "A8D49A21-02B9-429A-9C2D-E4A45CFFD228",
@@ -170,7 +165,6 @@
       {
         "nummer": "V",
         "prinsipalLovbud": {
-          "lovbudKombinertId": "02A6F54C-0F82-4489-82B6-9DE1C887DF29",
           "lovbud": [
             {
               "lovbudId": "E482BA83-2664-4BA6-8AB7-C0BDFF3CFBD5",
@@ -199,7 +193,6 @@
       {
         "nummer": "VI",
         "prinsipalLovbud": {
-          "lovbudKombinertId": "E5C3975D-6AE3-404B-91B7-A437C4620AEA",
           "lovbud": [
             {
               "lovbudId": "E482BA83-2664-4BA6-8AB7-C0BDFF3CFBD5",
@@ -242,7 +235,8 @@
         "etternavn": "BAR"
       },
       "identitetsnummer": {
-        "foedselsnummer": "29838099694"
+        "idType": "FOEDSELSNUMMER",
+        "verdi": "29838099694"
       },
       "tilleggsId": [],
       "kjoenn": "KVINNE",
@@ -252,16 +246,7 @@
           "kode": "NOR",
           "navn": "Norge"
         }
-      ],
-      "personAdresse": {
-        "adresse": {
-          "norge": {
-            "adresselinjer": ["Prestegårdsveien 14A"],
-            "postnummer": "1912",
-            "poststed": "ENEBAKK"
-          }
-        }
-      }
+      ]
     },
     {
       "personForetakRef": "BC2F7372-E548-4B2A-B5E9-0D009A9BA2DB",
@@ -270,7 +255,8 @@
         "etternavn": "KIWI"
       },
       "identitetsnummer": {
-        "foedselsnummer": "20923148036"
+        "idType": "FOEDSELSNUMMER",
+        "verdi": "20923148036"
       },
       "tilleggsId": [],
       "kjoenn": "KVINNE",
@@ -280,16 +266,7 @@
           "kode": "NOR",
           "navn": "Norge"
         }
-      ],
-      "personAdresse": {
-        "adresse": {
-          "norge": {
-            "adresselinjer": ["Åsliavegen 226"],
-            "postnummer": "2266",
-            "poststed": "ARNEBERG"
-          }
-        }
-      }
+      ]
     }
   ],
   "siktedeForetak": [],
@@ -300,7 +277,6 @@
         "fornavn": "Rala",
         "etternavn": "YOU"
       },
-      "tilleggsId": [],
       "kjoenn": "KVINNE",
       "foedselsdato": "2000-12-01",
       "statsborgerskap": [
@@ -317,9 +293,9 @@
         "etternavn": "JENTE"
       },
       "identitetsnummer": {
-        "foedselsnummer": "19839299845"
+        "idType": "FOEDSELSNUMMER",
+        "verdi": "19839299845"
       },
-      "tilleggsId": [],
       "kjoenn": "KVINNE",
       "foedselsdato": "1992-03-19",
       "statsborgerskap": [
@@ -327,16 +303,7 @@
           "kode": "NOR",
           "navn": "Norge"
         }
-      ],
-      "personAdresse": {
-        "adresse": {
-          "norge": {
-            "adresselinjer": ["O.j.moums Vei 18A"],
-            "postnummer": "1657",
-            "poststed": "TORP"
-          }
-        }
-      }
+      ]
     },
     {
       "personForetakRef": "1AD4BD7F-7A21-4B4B-9CAE-E0325F6EE2BD",
@@ -345,9 +312,9 @@
         "etternavn": "DAGBOK"
       },
       "identitetsnummer": {
-        "foedselsnummer": "04836396354"
+        "idType": "FOEDSELSNUMMER",
+        "verdi": "04836396354"
       },
-      "tilleggsId": [],
       "kjoenn": "MANN",
       "foedselsdato": "1963-03-04",
       "statsborgerskap": [
@@ -355,16 +322,7 @@
           "kode": "NOR",
           "navn": "Norge"
         }
-      ],
-      "personAdresse": {
-        "adresse": {
-          "norge": {
-            "adresselinjer": ["Hjellane 36"],
-            "postnummer": "6200",
-            "poststed": "STRANDA"
-          }
-        }
-      }
+      ]
     }
   ],
   "fornaermedeForetak": [],
@@ -376,10 +334,11 @@
           "gjerningstidspunktFra": "2022-07-01T00:00:00+01:00",
           "gjerningstidspunktTil": "2022-07-01T00:00:00+01:00",
           "gjerningssted": {
-            "norge": {
+            "adresse": {
               "adresselinjer": ["Wesselvegen 29"],
               "postnummer": "3740",
-              "poststed": "SKIEN"
+              "poststed": "SKIEN",
+              "land": { "kode": "NOR", "navn": "Norgen" }
             }
           }
         },
@@ -397,10 +356,11 @@
           "gjerningstidspunktFra": "2023-12-01T00:00:00+02:00",
           "gjerningstidspunktTil": "2023-12-01T00:00:00+02:00",
           "gjerningssted": {
-            "norge": {
+            "adresse": {
               "adresselinjer": ["Weidemanns gate 5"],
               "postnummer": "3080",
-              "poststed": "HOLMESTRAND"
+              "poststed": "HOLMESTRAND",
+              "land": { "kode": "NOR", "navn": "Norgen" }
             }
           }
         },
@@ -418,10 +378,11 @@
           "gjerningstidspunktFra": "2015-08-01T00:00:00+01:00",
           "gjerningstidspunktTil": "2015-11-01T00:00:00+02:00",
           "gjerningssted": {
-            "norge": {
+            "adresse": {
               "adresselinjer": ["Wergelands vei 11"],
               "postnummer": "3256",
-              "poststed": "LARVIK"
+              "poststed": "LARVIK",
+              "land": { "kode": "NOR", "navn": "Norgen" }
             }
           }
         },
@@ -439,10 +400,11 @@
           "gjerningstidspunktFra": "2015-08-01T00:00:00+01:00",
           "gjerningstidspunktTil": "2015-08-01T00:00:00+01:00",
           "gjerningssted": {
-            "norge": {
+            "adresse": {
               "adresselinjer": ["Wergelands vei 11"],
               "postnummer": "3256",
-              "poststed": "LARVIK"
+              "poststed": "LARVIK",
+              "land": { "kode": "NOR", "navn": "Norgen" }
             }
           }
         },
@@ -460,10 +422,11 @@
           "gjerningstidspunktFra": "2023-02-01T00:00:00+02:00",
           "gjerningstidspunktTil": "2023-02-01T00:00:00+02:00",
           "gjerningssted": {
-            "norge": {
+            "adresse": {
               "adresselinjer": ["Westadkleiva 9"],
               "postnummer": "3360",
-              "poststed": "GEITHUS"
+              "poststed": "GEITHUS",
+              "land": { "kode": "NOR", "navn": "Norgen" }
             }
           }
         },
@@ -481,10 +444,11 @@
           "gjerningstidspunktFra": "2018-11-11T00:00:00+02:00",
           "gjerningstidspunktTil": "2018-11-11T00:00:00+02:00",
           "gjerningssted": {
-            "norge": {
+            "adresse": {
               "adresselinjer": ["Wahlstrøms gate 9"],
               "postnummer": "3513",
-              "poststed": "HØNEFOSS"
+              "poststed": "HØNEFOSS",
+              "land": { "kode": "NOR", "navn": "Norgen" }
             }
           }
         },

--- a/kontrakter/siktelseTiltale/1.0/siktelseTiltale.schema.json
+++ b/kontrakter/siktelseTiltale/1.0/siktelseTiltale.schema.json
@@ -13,7 +13,7 @@
       "$ref": "#/definitions/straffesaksnummer",
       "description": "BL saksbehandlersak, trenger ikke være med i siktelsen (men er det som regel). Blir kalt hovedsaken i BL"
     },
-    "begjaeringAnmodning": {
+    "begjaeringAnmodningReferanse": {
       "$ref": "#/definitions/begjaeringAnmodningsId",
       "description": "Referanse til oversendelse siktelsen/tiltalen er en del av"
     },
@@ -21,7 +21,7 @@
     "siktedePersoner": {
       "type": "array",
       "description": "Alle siktede/tiltalte personer i siktelsen/tiltalen, kan være tom liste, hvis kun foretak er siktet/tiltalt",
-      "items": { "$ref": "#/definitions/siktetPerson" }
+      "items": { "$ref": "#/definitions/siktetPersonEnkel" }
     },
     "siktedeForetak": {
       "type": "array",
@@ -31,7 +31,7 @@
     "fornaermedePersoner": {
       "type": "array",
       "description": "Fornærmede personer.",
-      "items": { "$ref": "#/definitions/person" }
+      "items": { "$ref": "#/definitions/relatertPersonEnkel" }
     },
     "fornaermedeForetak": {
       "type": "array",
@@ -54,7 +54,7 @@
   "required": [
     "forsendelse",
     "hovedStraffesaksnummer",
-    "begjaeringAnmodning",
+    "begjaeringAnmodningReferanse",
     "siktelseTiltale",
     "siktedePersoner",
     "siktedeForetak",
@@ -66,6 +66,36 @@
   "additionalProperties": false,
 
   "definitions": {
+    "relatertPersonEnkel": {
+      "type": "object",
+      "description": "Personer som er fornærmed, vitner, verger der det ikke er krav om fødselsnummer, osv.",
+      "properties": {
+        "personForetakRef": {
+          "$ref": "#/definitions/GUID",
+          "description": "unik id kun lokalt i en melding, samme personForetakRef er samme person."
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": { "$ref": "#/definitions/dato" },
+        "kjoenn": {
+          "$ref": "#/definitions/kjoenn",
+          "description": "Ukjent kjønn hvis denne ikke er med"
+        },
+        "statsborgerskap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/land"
+          }
+        },
+        "identitetsnummer": {
+          "$ref": "#/definitions/personIdentifikator",
+          "description": "Fødselsnummer eller D-nummer. Vitner og verger skal aldri ha SSP nummer"
+        }
+      },
+      "required": ["personForetakRef", "navn", "statsborgerskap"],
+      "additionalProperties": false
+    },
     "basissakId": {
       "$ref": "#/definitions/unikId",
       "description": "Unik id for basissak, ved dom må denne id følge med og det skal vær definert skyld/ikke skyld"
@@ -76,11 +106,10 @@
       "properties": {
         "kravId": {
           "description": "Krav om avgjørelse kravId referanse til begjæring (varetekt, dom, annet) hvor denne siktelsen er vedlagt",
-          "format": "uuid",
-          "type": "string"
+          "$ref": "#/definitions/GUID"
         },
         "anmodningsId": {
-          "$ref": "#/definitions/unikId",
+          "$ref": "#/definitions/GUID",
           "description": "Referanse til anmodning som sendes KO, f.eks. bestilling av varetektsplass"
         }
       },
@@ -105,88 +134,6 @@
         }
       ]
     },
-    "adresse": {
-      "type": "object",
-      "description": "Norsk eller utenlandsk adresse",
-      "properties": {
-        "norge": {
-          "$ref": "#/definitions/adresseNorge",
-          "description": "Norsk adresse"
-        },
-        "utland": {
-          "$ref": "#/definitions/adresseUtland"
-        }
-      },
-      "oneOf": [
-        {
-          "properties": {
-            "norge": {
-              "$ref": "#/definitions/adresseNorge"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["norge"]
-        },
-        {
-          "properties": {
-            "utland": {
-              "$ref": "#/definitions/adresseUtland"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["utland"]
-        }
-      ]
-    },
-    "adresseNorge": {
-      "type": "object",
-      "description": "Norske med litt strengere validering på postnummer",
-      "properties": {
-        "adresselinjer": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 500
-          },
-          "maxItems": 4
-        },
-        "postnummer": {
-          "$ref": "#/definitions/norskPostnummer"
-        },
-        "poststed": {
-          "type": "string"
-        }
-      },
-      "required": ["adresselinjer", "postnummer"],
-      "additionalProperties": false
-    },
-    "adresseUtland": {
-      "type": "object",
-      "properties": {
-        "adresselinjer": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 500
-          },
-          "minItems": 1,
-          "maxItems": 4
-        },
-        "postnummer": {
-          "type": "string"
-        },
-        "poststed": {
-          "type": "string"
-        },
-        "land": {
-          "$ref": "#/definitions/land"
-        }
-      },
-      "required": ["adresselinjer"],
-      "additionalProperties": false
-    },
     "kodeverk": {
       "type": "object",
       "properties": {
@@ -200,17 +147,20 @@
       "required": ["kode"],
       "additionalProperties": false
     },
-    "kontaktInfoPerson": {
+    "kontaktInfo": {
       "type": "object",
-      "description": "Alle har epost adresse, men kanskje ikke registrert mobil/telefon",
+      "description": "Skal aldri forekomme med ingen verdier på epost eller telefonnummer",
       "properties": {
         "epost": {
-          "type": "string",
-          "format": "email"
+          "$ref": "#/definitions/epost"
         },
-        "telefonnummer": { "$ref": "#/definitions/telefonnummer" }
+        "telefonnummer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/telefonnummer"
+          }
+        }
       },
-      "required": ["epost"],
       "additionalProperties": false
     },
     "land": {
@@ -245,28 +195,6 @@
       "required": ["organisasjonsnummer", "navn"],
       "additionalProperties": false
     },
-    "paataleJurist": {
-      "type": "object",
-      "description": "Jurister hos påtale som er ansvarlig for straffesaker og aktorerer saker. Beholder brukeridentifikasjon pga. av gammel historikk og behov for identifisering.",
-      "properties": {
-        "brukeridentifikasjon": {
-          "type": "string",
-          "description": "BID hos politiet nå"
-        },
-        "tittel": {
-          "type": "string"
-        },
-        "navn": {
-          "$ref": "#/definitions/personnavn"
-        },
-        "kontakt": {
-          "$ref": "#/definitions/kontaktInfoPerson",
-          "description": "Frivillig fordi kan referere til en person som ikke lenger jobber i politiet"
-        }
-      },
-      "required": ["brukeridentifikasjon", "navn"],
-      "additionalProperties": false
-    },
     "ansattPerson": {
       "type": "object",
       "description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
@@ -278,25 +206,43 @@
           "$ref": "#/definitions/personnavn"
         },
         "kontakt": {
-          "$ref": "#/definitions/kontaktInfoPerson",
+          "$ref": "#/definitions/kontaktInfo",
           "description": "Er ikke med i første fase, burde inneholde kontaktinformasjon på forsendelsen."
         }
       },
       "required": ["navn", "kontakt"],
       "additionalProperties": false
     },
+    "ansattIDPerson": {
+      "type": "object",
+      "description": "Ansatt persom med brukeridentifikasjon for domstolene til vi har unik id på advokater/jurister",
+      "properties": {
+        "brukeridentifikasjon": {
+          "type": "string",
+          "description": "BID hos politiet skal erstattes med annen unik ID"
+        },
+        "tittel": {
+          "type": "string"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "kontakt": {
+          "$ref": "#/definitions/kontaktInfo",
+          "description": "Epost/telefon hvis personen fremdeles jobber i politiet."
+        }
+      },
+      "required": ["navn"],
+      "additionalProperties": false
+    },
     "forsendelse": {
       "type": "object",
       "properties": {
         "meldingsId": {
-          "description": "Unik ID for denne meldingen, hvis siktelsen blir sendt på nytt vil det være ny meldingsId",
-          "format": "uuid",
-          "type": "string"
+          "$ref": "#/definitions/GUID",
+          "description": "Unik ID for denne meldingen, hvis siktelsen blir sendt på nytt vil det være ny meldingsId"
         },
-        "sendtTid": {
-          "type": "string",
-          "format": "date-time"
-        },
+        "sendtTid": { "$ref": "#/definitions/datoTid" },
         "avsender": {
           "$ref": "#/definitions/avsender"
         },
@@ -331,10 +277,6 @@
       "type": "object",
       "description": "liste over lovbud hvis det straffbare forholdet har skjedde over en lovendring (kombinert)",
       "properties": {
-        "lovbudKombinertId": {
-          "$ref": "#/definitions/unikId",
-          "description": "Skal refereres til i resultatet"
-        },
         "lovbud": {
           "type": "array",
           "items": {
@@ -344,7 +286,7 @@
           "maxItems": 2
         }
       },
-      "required": ["lovbudKombinertId", "lovbud"],
+      "required": ["lovbud"],
       "additionalProperties": false
     },
 
@@ -387,70 +329,26 @@
       "required": ["fornavn", "etternavn"],
       "additionalProperties": false
     },
-    "foedselsnummer": {
-      "type": "string",
-      "description": "Se skatteetaten. Kan være vanlig med 6 sifret fødselsdato og fiktivt (Tenor) fødselsnummer med +80 på måned slik at noen født 10.01.1990 begynner fiktivt nummer med 108190",
-      "pattern": "^[0-3][0-9][0189][0-9]+$",
-      "minLength": 11,
-      "maxLength": 11
-    },
-    "sspNummer": {
-      "type": "string",
-      "description": "Personidentifikator brukt av det sentrale straffe- og personopplysningsregisteret (SSP) hvis personen ikke har fødselsnummer. Validerer som et fødselsnummer med +20 på måned så noen født 10.01.1990 begynner med 102190",
-      "pattern": "^[0-3][0-9][2-3][0-9]+$",
-      "minLength": 11,
-      "maxLength": 11
-    },
-    "dNummer": {
-      "type": "string",
-      "description": "Se skatteetaten. Dag på datodelen er +40. Født 10.01.1990, begynner med 51.01.90. Fiktivt (Tenor) dNummer vil har +80 på måned som for Tenor fødselsnummer",
-      "pattern": "^[4-7][0-9][0189][0-9]+$",
-      "minLength": 11,
-      "maxLength": 11
-    },
     "personIdentifikator": {
       "type": "object",
-      "description": "Fødselsnummer, D-nummer eller SSP nummer",
+      "description": "Fødselsnummer (inkl. Tenor), DNummer (inkl Tenor) eller SSP nummer som alle validerer til Modulus 11",
       "properties": {
-        "foedselsnummer": {
-          "$ref": "#/definitions/foedselsnummer"
-        },
-        "sspNummer": {
-          "$ref": "#/definitions/sspNummer"
-        },
-        "dNummer": {
-          "$ref": "#/definitions/dNummer"
+        "idType": { "$ref": "#/definitions/personIdType" },
+        "verdi": {
+          "type": "string",
+          "description": "Se skatteetaten. Kan være vanlig med 6 sifret fødselsdato og fiktivt (Tenor) fødselsnummer med +80 på måned slik at noen født 10.01.1990 begynner fiktivt nummer med 108190",
+          "pattern": "^[0-7][0-9][012389][0-9]+$",
+          "minLength": 11,
+          "maxLength": 11
         }
       },
-      "oneOf": [
-        {
-          "properties": {
-            "foedselsnummer": {
-              "$ref": "#/definitions/foedselsnummer"
-            }
-          },
-          "required": ["foedselsnummer"],
-          "additionalProperties": false
-        },
-        {
-          "properties": {
-            "sspNummer": {
-              "$ref": "#/definitions/sspNummer"
-            }
-          },
-          "required": ["sspNummer"],
-          "additionalProperties": false
-        },
-        {
-          "properties": {
-            "dNummer": {
-              "$ref": "#/definitions/dNummer"
-            }
-          },
-          "required": ["dNummer"],
-          "additionalProperties": false
-        }
-      ]
+      "required": ["idType", "verdi"],
+      "additionalProperties": false
+    },
+    "personIdType": {
+      "type": "string",
+      "description": "Person ID typer, alle valideres med Modulus 11",
+      "enum": ["FOEDSELSNUMMER", "DNUMMER", "SSPNUMMER"]
     },
     "foretak": {
       "type": "object",
@@ -458,18 +356,13 @@
       "properties": {
         "personForetakRef": {
           "description": "unik id kun lokalt i en melding, samme personForetakRef er samme foretak.",
-          "format": "uuid",
-          "type": "string"
+          "$ref": "#/definitions/GUID"
         },
         "organisasjonsnummer": {
           "$ref": "#/definitions/organisasjonsnummer"
         },
         "navn": {
           "type": "string"
-        },
-        "adresse": {
-          "$ref": "#/definitions/adresse",
-          "description": "hvis adresse er ugyldig, f.eks. skrevet ned koordinater i vanlig adresse så blir den ikke med."
         }
       },
       "required": ["personForetakRef", "navn"],
@@ -480,37 +373,21 @@
       "description": "Samme enum som folkeregisteret",
       "enum": ["KVINNE", "MANN"]
     },
-    "personAdresse": {
+    "siktetPersonEnkel": {
       "type": "object",
-      "description": "Kan være graderte adresser",
-      "properties": {
-        "gradering": {
-          "$ref": "#/definitions/adresseGradering",
-          "description": "Vi sender ikke med graderte adresser bortsett fra kanskje KLIENT_ADRESSE (sjekker)"
-        },
-        "adresse": {
-          "$ref": "#/definitions/adresse"
-        }
-      },
-      "required": ["adresse"],
-      "additionalProperties": false
-    },
-    "siktetPerson": {
-      "type": "object",
-      "description": "Person med alle nyttige data som fødselsnummer adresse osv., SSP nummer kun på siktede, tiltalte.",
+      "description": "Siktede, dømte, tiltalte... personer bruker denne typen for identifiserende data.",
       "properties": {
         "personForetakRef": {
-          "description": "Unik id kun lokalt i en melding, samme person kun i denne meldingen vil ha samme personForetakRef.",
-          "format": "uuid",
-          "type": "string"
+          "$ref": "#/definitions/GUID",
+          "description": "Unik id kun lokalt i en melding, samme person kun i denne meldingen vil ha samme personForetakRef."
+        },
+        "personStraffesakId": {
+          "$ref": "#/definitions/personStraffesakId"
         },
         "navn": {
           "$ref": "#/definitions/personnavn"
         },
-        "foedselsdato": {
-          "type": "string",
-          "format": "date"
-        },
+        "foedselsdato": { "$ref": "#/definitions/dato" },
         "kjoenn": {
           "$ref": "#/definitions/kjoenn",
           "description": "Ukjent kjønn hvis denne ikke er med"
@@ -531,13 +408,6 @@
             "$ref": "#/definitions/personIdentifikator"
           },
           "description": "Kan være SSP nummer hvis person har D-nummer, fremtidig historiske nummer?"
-        },
-        "adresseGradering": {
-          "$ref": "#/definitions/adresseGradering",
-          "description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå"
-        },
-        "personAdresse": {
-          "$ref": "#/definitions/personAdresse"
         }
       },
       "required": [
@@ -547,60 +417,6 @@
         "statsborgerskap",
         "tilleggsId",
         "identitetsnummer"
-      ],
-      "additionalProperties": false
-    },
-    "person": {
-      "type": "object",
-      "description": "Person som ikke er siktet eller tiltalt, vil aldri ha SSP nummer",
-      "properties": {
-        "personForetakRef": {
-          "description": "Unik id kun lokalt i en melding, samme person kun i denne meldingen vil ha samme personForetakRef.",
-          "format": "uuid",
-          "type": "string"
-        },
-        "navn": {
-          "$ref": "#/definitions/personnavn"
-        },
-        "foedselsdato": {
-          "type": "string",
-          "format": "date"
-        },
-        "kjoenn": {
-          "$ref": "#/definitions/kjoenn",
-          "description": "Ukjent kjønn hvis denne ikke er med"
-        },
-        "statsborgerskap": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/land"
-          }
-        },
-        "identitetsnummer": {
-          "$ref": "#/definitions/personIdentifikator",
-          "description": "Fødselsnummer eller D-nummer."
-        },
-        "tilleggsId": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/personIdentifikator"
-          },
-          "description": "D-nummer, tidligere fødselsnummer ?"
-        },
-        "adresseGradering": {
-          "$ref": "#/definitions/adresseGradering",
-          "description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå"
-        },
-        "personAdresse": {
-          "$ref": "#/definitions/personAdresse"
-        }
-      },
-      "required": [
-        "personForetakRef",
-        "navn",
-        "foedselsdato",
-        "statsborgerskap",
-        "tilleggsId"
       ],
       "additionalProperties": false
     },
@@ -676,7 +492,7 @@
       "type": "object",
       "description": "Strukturert siktelse/tiltale.",
       "properties": {
-        "siktelsesId": { "$ref": "#/definitions/unikId" },
+        "siktelsesId": { "$ref": "#/definitions/GUID" },
         "siktelsesType": { "$ref": "#/definitions/siktelsesType" },
         "poster": {
           "type": "array",
@@ -687,32 +503,15 @@
           "minItems": 1
         },
         "skrevetAv": {
-          "$ref": "#/definitions/paataleJurist",
-          "description": "Person som har skrevet under siktelsen."
+          "$ref": "#/definitions/ansattIDPerson",
+          "description": "Jurist som har skrevet under siktelsen (en påtaleansvarlig)"
         },
-        "dokument": {
+        "dokumentRef": {
           "$ref": "#/definitions/dokumentRef",
           "description": "Referanse til siktelsesdokumentet (PDF) som er vedlagt meldingen"
         }
       },
       "required": ["siktelsesId", "siktelsesType", "poster", "skrevetAv"],
-      "additionalProperties": false
-    },
-    "hendelse": {
-      "type": "object",
-      "description": "Tid og sted for det straffbare forholdet",
-      "properties": {
-        "gjerningstidspunktFra": { "$ref": "#/definitions/lokalTid" },
-        "gjerningstidspunktTil": { "$ref": "#/definitions/lokalTid" },
-        "gjerningssted": {
-          "$ref": "#/definitions/adresse"
-        }
-      },
-      "required": [
-        "gjerningstidspunktFra",
-        "gjerningstidspunktTil",
-        "gjerningssted"
-      ],
       "additionalProperties": false
     },
     "straffbartForhold": {
@@ -754,10 +553,10 @@
     },
     "straffesak": {
       "type": "object",
-      "description": "Straffesak, hendelse og koding og fornærmede som ikke er med i siktelsen",
+      "description": "Straffesak, hendelse og koding og fornærmede som er med i siktelsen",
       "properties": {
         "straffesaksnummer": {
-          "type": "string"
+          "$ref": "#/definitions/straffesaksnummer"
         },
         "detaljer": {
           "$ref": "#/definitions/straffesakDetaljer"
@@ -768,7 +567,7 @@
           "items": { "$ref": "#/definitions/personForetakRef" }
         }
       },
-      "required": ["straffesaksnummer", "detaljer", "fornaermede"],
+      "required": ["straffesaksnummer", "detaljer"],
       "additionalProperties": false
     },
     "straffesakDetaljer": {
@@ -788,15 +587,116 @@
       "required": ["hendelse", "statistikkgruppe"],
       "additionalProperties": false
     },
-
+    "hendelse": {
+      "type": "object",
+      "description": "Tid og sted for det straffbare forholdet",
+      "properties": {
+        "gjerningstidspunktFra": { "$ref": "#/definitions/datoTid" },
+        "gjerningstidspunktTil": { "$ref": "#/definitions/datoTid" },
+        "gjerningssted": {
+          "$ref": "#/definitions/sted"
+        }
+      },
+      "required": [
+        "gjerningstidspunktFra",
+        "gjerningstidspunktTil",
+        "gjerningssted"
+      ],
+      "additionalProperties": false
+    },
+    "sted": {
+      "type": "object",
+      "description": "Et sted kan være en adresse, en posisjon, eller bare en beskrivelse som krysset på Klett. I dag vil det alltid være en adresse eller en posisjon (se readme.md)",
+      "properties": {
+        "beskrivelse": { "type": "string" },
+        "adresse": { "$ref": "#/definitions/adresse" },
+        "posisjon": {
+          "$ref": "#/definitions/koordinat",
+          "description": "Skal være mulig å sende adresse og posisjon sammen senere."
+        }
+      },
+      "additionalProperties": false
+    },
+    "koordinat": {
+      "type": "object",
+      "description": "UTM koordinater eller bredde lengdegrad",
+      "properties": {
+        "breddeLengdeDesimal": { "$ref": "#/definitions/breddeLengdeDesimal" },
+        "UTM": { "$ref": "#/definitions/UTM" }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "UTM": { "$ref": "#/definitions/UTM" }
+          },
+          "required": ["UTM"]
+        },
+        {
+          "properties": {
+            "breddeLengdeDesimal": {
+              "$ref": "#/definitions/breddeLengdeDesimal"
+            }
+          },
+          "required": ["breddeLengdeDesimal"]
+        }
+      ]
+    },
+    "UTM": {
+      "type": "object",
+      "description": "UTM koordinater, EUREF89, vil være sone 33 nordlige halvkule for straffesaker",
+      "properties": {
+        "oest": { "type": "integer" },
+        "nord": { "type": "integer" },
+        "srid": {
+          "type": "integer",
+          "description": "Spatial Reference System Identifier (SRID), 32633=UTM33N"
+        }
+      },
+      "required": ["oest", "nord", "srid"],
+      "additionalProperties": false
+    },
+    "breddeLengdeDesimal": {
+      "type": "object",
+      "description": "bredde lengde koordinater desimal minutt og sekund (maks 5 desimaler i bredde/lengde",
+      "properties": {
+        "bredde": { "type": "number", "minimum": -90, "maximum": 90 },
+        "lengde": { "type": "number", "minimum": -180, "maximum": 180 },
+        "srid": {
+          "type": "integer",
+          "description": "Spatial Reference System Identifier (SRID), 4326=WGS84 for alle fra straffesak"
+        }
+      },
+      "required": ["bredde", "lengde", "srid"],
+      "additionalProperties": false
+    },
+    "adresse": {
+      "type": "object",
+      "properties": {
+        "adresselinjer": {
+          "type": "array",
+          "items": { "type": "string" },
+          "maxItems": 4
+        },
+        "postnummer": {
+          "type": "string"
+        },
+        "poststed": {
+          "type": "string"
+        },
+        "land": {
+          "$ref": "#/definitions/land"
+        }
+      },
+      "required": ["adresselinjer", "land"],
+      "additionalProperties": false
+    },
     "dokument": {
       "type": "object",
       "description": "Dokument som oversendes på justishub",
       "properties": {
         "dokumentRef": {
           "description": "Unik id for dokumentet kun lokalt i en melding. Bruker dokumentRef for å referere",
-          "format": "uuid",
-          "type": "string"
+          "$ref": "#/definitions/GUID"
         },
         "kategori": {
           "$ref": "#/definitions/kodeverk"
@@ -806,8 +706,7 @@
           "description": "Overskrift/tittel i straffesaken sin dokumentliste, er ikke det samme som tittel skrevet inn i dokumentet"
         },
         "skrevetDato": {
-          "type": "string",
-          "format": "date",
+          "$ref": "#/definitions/dato",
           "description": "Når dokumentet er skrevet ferdig."
         },
         "forsendelse": {
@@ -835,13 +734,11 @@
       "additionalProperties": false
     },
     "dokumentRef": {
-      "format": "uuid",
-      "type": "string"
+      "$ref": "#/definitions/GUID"
     },
     "personForetakRef": {
       "description": "Referanse inn person eller foretak lister",
-      "format": "uuid",
-      "type": "string"
+      "$ref": "#/definitions/GUID"
     },
     "organisasjonsnummer": {
       "type": "string",
@@ -849,11 +746,6 @@
       "pattern": "^[0-9]+$",
       "minLength": 9,
       "maxLength": 9
-    },
-    "lokalTid": {
-      "type": "string",
-      "description": "Lokal tid uten tidssone. 2023-04-03T12:33:45 ISO 8601 uten tidssone. Det vil ikke være med millisekunder.",
-      "format": "date-time"
     },
     "norskPostnummer": {
       "type": "string",
@@ -868,10 +760,18 @@
       "minLength": 3,
       "maxLength": 30
     },
+    "personStraffesakId": {
+      "$ref": "#/definitions/unikId",
+      "description": "Referanse til person i straffesak, se readme"
+    },
+    "epost": {
+      "type": "string",
+      "format": "email"
+    },
     "telefonnummer": {
       "type": "string",
       "description": "Ett telefonnummer, norsk eller utenlands, med eller uten land prefix. Tillater +før landkode, - tegn, space og paranteser.",
-      "pattern": "^\\+?[0-9, ,\\-,\\(,)]*$",
+      "pattern": "^\\+?[0-9 ()-]*$",
       "maxLength": 30,
       "minLength": 3
     },
@@ -880,6 +780,18 @@
       "description": "GUID eller andre unike id'er. Trenger ikke være global unik.",
       "maxLength": 40,
       "minLength": 5
+    },
+    "datoTid": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "dato": {
+      "type": "string",
+      "format": "date"
+    },
+    "GUID": {
+      "type": "string",
+      "format": "uuid"
     }
   }
 }

--- a/kontrakter/siktelseTiltale/changelog.md
+++ b/kontrakter/siktelseTiltale/changelog.md
@@ -5,3 +5,15 @@
 | 0.0     | Arbeidsverson |            ||
 
 ## Versjon 0.0 arbeidsversjon
+### 21.08.2024 Synkroniserer 
+Fullbyrdelsesordre og bestilling av varetekt typer.
+
+Bruk av dato datoTid, GUID typer, epost.
+siktetPerson ny, alle detaljer som adresser osv. skal ligge i begjæring, bestilling ....
+kun id type data.
+fornaermedePerson uten adresse osv. 
+kontaktInfo felles.
+Straffesak nå også med koordinater hvis gjerningssted ikke er en adresse.
+adresse forenklet og som fullbyrdelse/bestilling.
+lovbudKombinertId utgår, vi bruker bare lovbud id'er
+Fjerner kommune fra sted da det er kun for pågripelsessted som er noe annet.

--- a/kontrakter/siktelseTiltale/readme.md
+++ b/kontrakter/siktelseTiltale/readme.md
@@ -3,7 +3,8 @@ Versjon 1.0 er første versjon som vi skal i produksjon med sammen med tilståel
 
 ## Headere forsendelse justisHub
 SchemaName=SIKTELSE_TILTALE  
-SchemaVersion=1.0  
+SchemaVersion=1.0
+senderOrganization=POLITIET  
 [RFC](../../rfc/MessageName-header.md)  
 [Se changelog for endringer](changelog.md)
 

--- a/kontrakter/siktelseTiltale/readme.md
+++ b/kontrakter/siktelseTiltale/readme.md
@@ -7,33 +7,32 @@ SchemaVersion=1.0
 [RFC](../../rfc/MessageName-header.md)  
 [Se changelog for endringer](changelog.md)
 
+
 ## Status
-2. runde med kommentarer fra domstolene, sender ut til ny PR.
+3. runde synkroniser med arbeid gjort på fullbyrdelse osv. for typer
+
+## beskrivelse
+En siktelse/tiltale en liste over basissaker som skal avgjøres.
+En basissak er et straffbart forhold (tid og sted), et lovbud og en siktet/tiltalt person.
+Ref. Harmoniseringsrapporten.
 
 ## Utestående punkter
-### Kodeverk
-Bedre løsning på kodeverk, hvordan skal vi kunne dele politiets kodeverk.
+### Fornærmede
+Siktelser som tas ut kan være i tidlig fase og straffesakene kan inneholde flere fornærmede som ikke nødvendigvis er med i siktelsen, ref. problem
+med personundersøkelse i Sør-Vest politidistrikt.
+Avklaring med påtalejurister, flere runder.
 ### Kontakt
 Hvis det er noe trøbbel spørsmål med en begjæring om tilståelsessak, hvem skal domstolen kontakte hos politiet?
 Legger ved informasjon om avsender inkludert epost adresse og telefon hvis det finnes.
  spesifikke kontaktdetaljer fordi det er begjæringen om tilståelse som skal fange alle, men hvis vi ettersender hva da (meddomssaker)
 
-### Adresser kommer med oppdatering
-Dekker ikke alle tilfeller nå, adresse med gate,navn osv. er greit, men offshore, og annet lurt er ikke dekket.
-Ønsker ikke veldig mange versjoner.
-
-## skjemadealjer
-### internId
-internId brukes på referanser innenfor en melding og lever ikke utenfor en melding, hvis samme siktelse/begjæring sendes på nytt så vil de kanskje ha nye id'er
-
-## Siktelse / tiltale
-Ref Harmoniseringsrapporten av 2006 så er en siktelse/tiltale en liste over basissaker som skal avgjøres.
-En basissak er et straffbart forhold (tid og sted), et lovbud og en siktet/tiltalt person.
+## felter
 
 ### basissak
 Se [basissak](basissak.md). Domstolene skal avgjøre alle basissaker med skyld ikke skyld.
 _Sjekk opp fordi i Harmoniseringsrapporten står det straffeskyld / ikke straffeskyld_
 _Hva skjer med saker der personen ikke har skyldevne Straffeloven § 20, blir det fremedeles dømt skyldig / ikke skyldig ?_
+
 ### Kombinert lovbud
 Når en forbrytelse har foregått over tid og vi har hatt en lovendring i den perioden så er det mulig å definere flere lovbud som gjelder for den straffbare handlingen.
 <!-- Eksempel på en slik post --> 
@@ -42,9 +41,16 @@ Denne funksjonaliteten ble innført når ny straffelov ble aktivert i 2015. <!--
 ### inkluderte forhold
 Enkelte lovbrudd kan slås sammen hvis de er pågått flere ganger over en periode slik at det blir bare ett grunnlag med en et annet lovbud.
 _Finn eksempel, kanskje bruk av narkotika flere ganger til i perioden har NN blitt tatt 4 gangaer i bruke av Narkotika_
+
 ### straffbart forhold
 Ett Straffbart forhold vil ha sitt utspring i en Hendelse (ev. en serie Hendelser av samme type) som  antas å være straffbar og skal etterforskes. I BL/STRASAK modeleres et straffbart forhold som en straffesak med hendelse, kobling til personer/foretak.
 I BL så har et straffbart forhold et prinsipal lovbud med grunnlag og et subsidiært lovbud med grunnlag. Dvs. hvis en hendelse er opphave til flere lovbrudd så lages det flere straffesaker (straffbare forhold).
+
 ### Subsidiære lovbud
 En straffesak kan ha et subsidiært lovbud og i BL sin implementasjon av siktelse så kan en post samle alle straffesaker som har samme prinsipale lovbud selv om de subsidiære lovbudene er forskjellig.
 _Vi har ikke fått snakket med fagpersoner om det er vanlig å bruke._
+
+### personStraffesakId
+Nøkkel for personer som er siktet (tiltalt, domfelt) som ikke skal endre seg mellom oversendelser til domstolene/kriminalomsorgen.
+Denne er ikke utviklet i BL ennå så derfor er den optional.
+* Det vil være tilfeller der samme person vil får nye nøkler. Det er avhengig av hvordan det blir registrert og ryddet i BL.


### PR DESCRIPTION
Endringer (fra changelog):
Bruk av dato datoTid, GUID typer, epost.
siktetPerson ny, alle detaljer som adresser osv. skal ligge i begjæring, bestilling ....
kun id type data.
fornaermedePerson uten adresse osv. 
kontaktInfo felles.
Straffesak nå også med koordinater hvis gjerningssted ikke er en adresse.
adresse forenklet og som fullbyrdelse/bestilling.
lovbudKombinertId utgår, vi bruker bare lovbud id'er
Fjerner kommune fra sted da det er kun for pågripelsessted som er noe annet.