### PR TITLE
Mindre persondata i siktelseTiltale

### DIFF
--- a/kontrakter/siktelseTiltale/1.0/eksempelfiler/siktelseTiltale-eksempel-1.json
+++ b/kontrakter/siktelseTiltale/1.0/eksempelfiler/siktelseTiltale-eksempel-1.json
@@ -92,59 +92,11 @@
         "idType": "FOEDSELSNUMMER",
         "verdi": "22918197870"
       },
-      "tilleggsId": [],
       "kjoenn": "KVINNE",
-      "foedselsdato": "1981-11-22",
-      "statsborgerskap": [
-        {
-          "kode": "NOR",
-          "navn": "Norge"
-        }
-      ]
+      "foedselsdato": "1981-11-22"
     }
   ],
   "siktedeForetak": [],
-  "fornaermedePersoner": [
-    {
-      "personForetakRef": "F34CAFDB-F3FB-4AC9-8FE0-2463BA57FC16",
-      "navn": {
-        "fornavn": "Entusiastisk",
-        "etternavn": "HARE"
-      },
-      "identitetsnummer": {
-        "idType": "FOEDSELSNUMMER",
-        "verdi": "25835799770"
-      },
-      "kjoenn": "MANN",
-      "foedselsdato": "1957-03-25",
-      "statsborgerskap": [
-        {
-          "kode": "NOR",
-          "navn": "Norge"
-        }
-      ]
-    },
-    {
-      "personForetakRef": "922E9192-CBB8-4A32-B2CC-CA7B3498D484",
-      "navn": {
-        "fornavn": "Fiolett",
-        "etternavn": "POSTKASSE"
-      },
-      "identitetsnummer": {
-        "idType": "FOEDSELSNUMMER",
-        "verdi": "15858796374"
-      },
-      "kjoenn": "MANN",
-      "foedselsdato": "1987-05-15",
-      "statsborgerskap": [
-        {
-          "kode": "NOR",
-          "navn": "Norge"
-        }
-      ]
-    }
-  ],
-  "fornaermedeForetak": [],
   "straffesaker": [
     {
       "straffesaksnummer": "15439561",

--- a/kontrakter/siktelseTiltale/1.0/eksempelfiler/siktelseTiltale-eksempel-2.json
+++ b/kontrakter/siktelseTiltale/1.0/eksempelfiler/siktelseTiltale-eksempel-2.json
@@ -238,15 +238,8 @@
         "idType": "FOEDSELSNUMMER",
         "verdi": "29838099694"
       },
-      "tilleggsId": [],
       "kjoenn": "KVINNE",
-      "foedselsdato": "1980-03-29",
-      "statsborgerskap": [
-        {
-          "kode": "NOR",
-          "navn": "Norge"
-        }
-      ]
+      "foedselsdato": "1980-03-29"
     },
     {
       "personForetakRef": "BC2F7372-E548-4B2A-B5E9-0D009A9BA2DB",
@@ -258,74 +251,11 @@
         "idType": "FOEDSELSNUMMER",
         "verdi": "20923148036"
       },
-      "tilleggsId": [],
       "kjoenn": "KVINNE",
-      "foedselsdato": "1931-12-20",
-      "statsborgerskap": [
-        {
-          "kode": "NOR",
-          "navn": "Norge"
-        }
-      ]
+      "foedselsdato": "1931-12-20"
     }
   ],
   "siktedeForetak": [],
-  "fornaermedePersoner": [
-    {
-      "personForetakRef": "FC894809-0F66-46AE-BC59-A19CE86250B5",
-      "navn": {
-        "fornavn": "Rala",
-        "etternavn": "YOU"
-      },
-      "kjoenn": "KVINNE",
-      "foedselsdato": "2000-12-01",
-      "statsborgerskap": [
-        {
-          "kode": "DZA",
-          "navn": "Algerie"
-        }
-      ]
-    },
-    {
-      "personForetakRef": "625DE28C-43B4-4F46-AAB4-5D835CE8B794",
-      "navn": {
-        "fornavn": "Trådløs",
-        "etternavn": "JENTE"
-      },
-      "identitetsnummer": {
-        "idType": "FOEDSELSNUMMER",
-        "verdi": "19839299845"
-      },
-      "kjoenn": "KVINNE",
-      "foedselsdato": "1992-03-19",
-      "statsborgerskap": [
-        {
-          "kode": "NOR",
-          "navn": "Norge"
-        }
-      ]
-    },
-    {
-      "personForetakRef": "1AD4BD7F-7A21-4B4B-9CAE-E0325F6EE2BD",
-      "navn": {
-        "fornavn": "Deilig",
-        "etternavn": "DAGBOK"
-      },
-      "identitetsnummer": {
-        "idType": "FOEDSELSNUMMER",
-        "verdi": "04836396354"
-      },
-      "kjoenn": "MANN",
-      "foedselsdato": "1963-03-04",
-      "statsborgerskap": [
-        {
-          "kode": "NOR",
-          "navn": "Norge"
-        }
-      ]
-    }
-  ],
-  "fornaermedeForetak": [],
   "straffesaker": [
     {
       "straffesaksnummer": "15439559",

--- a/kontrakter/siktelseTiltale/1.0/siktelseTiltale.schema.json
+++ b/kontrakter/siktelseTiltale/1.0/siktelseTiltale.schema.json
@@ -28,16 +28,6 @@
       "description": "Alle siktede foretak. Kan være tom liste",
       "items": { "$ref": "#/definitions/foretak" }
     },
-    "fornaermedePersoner": {
-      "type": "array",
-      "description": "Fornærmede personer.",
-      "items": { "$ref": "#/definitions/relatertPersonEnkel" }
-    },
-    "fornaermedeForetak": {
-      "type": "array",
-      "description": "Alle fornaermede foretak. Kan være tom liste",
-      "items": { "$ref": "#/definitions/foretak" }
-    },
     "straffesaker": {
       "type": "array",
       "description": "Alle straffesaker (straffbare forhold nesten) som er med i siktelsen/tiltalen eller saksbehandlingssaken",
@@ -58,44 +48,12 @@
     "siktelseTiltale",
     "siktedePersoner",
     "siktedeForetak",
-    "fornaermedePersoner",
-    "fornaermedeForetak",
     "straffesaker",
     "dokumenter"
   ],
   "additionalProperties": false,
 
   "definitions": {
-    "relatertPersonEnkel": {
-      "type": "object",
-      "description": "Personer som er fornærmed, vitner, verger der det ikke er krav om fødselsnummer, osv.",
-      "properties": {
-        "personForetakRef": {
-          "$ref": "#/definitions/GUID",
-          "description": "unik id kun lokalt i en melding, samme personForetakRef er samme person."
-        },
-        "navn": {
-          "$ref": "#/definitions/personnavn"
-        },
-        "foedselsdato": { "$ref": "#/definitions/dato" },
-        "kjoenn": {
-          "$ref": "#/definitions/kjoenn",
-          "description": "Ukjent kjønn hvis denne ikke er med"
-        },
-        "statsborgerskap": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/land"
-          }
-        },
-        "identitetsnummer": {
-          "$ref": "#/definitions/personIdentifikator",
-          "description": "Fødselsnummer eller D-nummer. Vitner og verger skal aldri ha SSP nummer"
-        }
-      },
-      "required": ["personForetakRef", "navn", "statsborgerskap"],
-      "additionalProperties": false
-    },
     "basissakId": {
       "$ref": "#/definitions/unikId",
       "description": "Unik id for basissak, ved dom må denne id følge med og det skal vær definert skyld/ikke skyld"
@@ -392,30 +350,15 @@
           "$ref": "#/definitions/kjoenn",
           "description": "Ukjent kjønn hvis denne ikke er med"
         },
-        "statsborgerskap": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/land"
-          }
-        },
         "identitetsnummer": {
           "$ref": "#/definitions/personIdentifikator",
           "description": "Fødselsnummer, D-nummer eller SSP nummer som er i bruk. Siktede vil alltid ha med denne."
-        },
-        "tilleggsId": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/personIdentifikator"
-          },
-          "description": "Kan være SSP nummer hvis person har D-nummer, fremtidig historiske nummer?"
         }
       },
       "required": [
         "personForetakRef",
         "navn",
         "foedselsdato",
-        "statsborgerskap",
-        "tilleggsId",
         "identitetsnummer"
       ],
       "additionalProperties": false

--- a/kontrakter/siktelseTiltale/changelog.md
+++ b/kontrakter/siktelseTiltale/changelog.md
@@ -5,6 +5,12 @@
 | 0.0     | Arbeidsverson |            ||
 
 ## Versjon 0.0 arbeidsversjon
+### 23.09.2024 personinformasjon
+Fjerner fornærmede da de sendes i begjaeringDom. (liten endring i begjaeringDom i egen PR).
+Siktelsen kan teknisk inneholde flere siktede så beholder navn, kjønn og fødselsdato i tillegg til identifikator.
+Hvis det er behov for fornærmede/foretak i siktelsen så bør det gjøres endringer i BL for å sørge for at
+siktelsesdokumentet og det strukturerte er likt også med hensyn på fornærmede.
+
 ### 18.09.2024 anmodningsId
 begjaeringAnmodningsId og anmodningsId skal være GUID overalt også i oneOf definisjon.
 ### 21.08.2024 Synkroniserer 

--- a/kontrakter/siktelseTiltale/readme.md
+++ b/kontrakter/siktelseTiltale/readme.md
@@ -10,12 +10,13 @@ senderOrganization=POLITIET
 
 
 ## Status
-3. runde synkroniser med arbeid gjort på fullbyrdelse osv. for typer
+Klart til tilståelsessaker og bestilling av varetektsplass.
 
 ## beskrivelse
 En siktelse/tiltale en liste over basissaker som skal avgjøres.
 En basissak er et straffbart forhold (tid og sted), et lovbud og en siktet/tiltalt person.
 Ref. Harmoniseringsrapporten.
+Det er en ren siktelse der fornærmede ikke er en del av de strukturerte data.
 
 ## Utestående punkter
 ### Fornærmede


### PR DESCRIPTION
Det blir ikke helt fjernet pga. medsiktede
changelog.md
Fjerner fornærmede da de sendes i begjaeringDom. (liten endring i begjaeringDom i egen PR).
Siktelsen kan teknisk inneholde flere siktede så beholder navn, kjønn og fødselsdato i tillegg til identifikator.
Hvis det er behov for fornærmede/foretak i siktelsen så bør det gjøres endringer i BL for å sørge for at
siktelsesdokumentet og det strukturerte er likt også med hensyn på fornærmede.
