### PR TITLE
Fjern uavklart fra innsettelsesordre

### DIFF
--- a/kontrakter/varetekt/innsettelsesordre/1.0/eksempelfiler/innsettelsesordre-eksempel-1.json
+++ b/kontrakter/varetekt/innsettelsesordre/1.0/eksempelfiler/innsettelsesordre-eksempel-1.json
@@ -64,7 +64,6 @@
           "isolasjonsType": "FULL_ISOLASJON"
         }
       ],
-      "uavklart": false,
       "beskrivelse": "Bestemor får komme med lutfesk"
     }
   },

--- a/kontrakter/varetekt/innsettelsesordre/1.0/innsettelsesordre.schema.json
+++ b/kontrakter/varetekt/innsettelsesordre/1.0/innsettelsesordre.schema.json
@@ -302,15 +302,11 @@
             "$ref": "#/definitions/isolasjon"
           }
         },
-        "uavklart": {
-          "type": "boolean",
-          "description": "Vet ikke ennå hva slags restriksjonskrav som vil bli stilt."
-        },
         "beskrivelse": {
           "type": "string"
         }
       },
-      "required": ["restriksjonskrav", "isolasjonskrav", "uavklart"],
+      "required": ["restriksjonskrav", "isolasjonskrav"],
       "additionalProperties": false
     },
     "restriksjon": {


### PR DESCRIPTION
Valg for uavklarte restriksjoner fjernes for innsettelesesordre da det ikke skal være aktuelt ved selve innsettelsesordren