### PR TITLE
Definer identitetsnummer for person i vegtrafikkulykke og gjør den optional

### DIFF
--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/eksempelfiler/trafikkulykke-eksempel-1.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/eksempelfiler/trafikkulykke-eksempel-1.json
@@ -83,6 +83,7 @@
         "reguleringEnhetVegkryss": "FORKJOERSVEI",
         "personer": [
           {
+            "id": "person_1",
             "identitetsnummer": {
               "idType": "FOEDSELSNUMMER",
               "verdi": "22918197870"
@@ -99,6 +100,7 @@
             "poststed": "Røyse"
           },
           {
+            "id": "person_2",
             "kjoenn": "KVINNE",
             "foedselsdato": "2022-02-12",
             "plasseringKjoeretoey": "BAK",
@@ -118,6 +120,7 @@
         "reguleringEnhetVegkryss": "ANNEN_REGULERING_I_KRYSS_INKL_MIDLERTIDIG",
         "personer": [
           {
+            "id": "person_3",
             "identitetsnummer": {
               "idType": "FOEDSELSNUMMER",
               "verdi": "22918197881"

--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/eksempelfiler/trafikkulykke-eksempel-1.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/eksempelfiler/trafikkulykke-eksempel-1.json
@@ -83,7 +83,10 @@
         "reguleringEnhetVegkryss": "FORKJOERSVEI",
         "personer": [
           {
-            "id": "person_1",
+            "identitetsnummer": {
+              "idType": "FOEDSELSNUMMER",
+              "verdi": "22918197870"
+            },
             "kjoenn": "MANN",
             "foedselsdato": "1977-11-11",
             "plasseringKjoeretoey": "FOERERPLASS",
@@ -96,7 +99,6 @@
             "poststed": "Røyse"
           },
           {
-            "id": "person_2",
             "kjoenn": "KVINNE",
             "foedselsdato": "2022-02-12",
             "plasseringKjoeretoey": "BAK",
@@ -116,7 +118,10 @@
         "reguleringEnhetVegkryss": "ANNEN_REGULERING_I_KRYSS_INKL_MIDLERTIDIG",
         "personer": [
           {
-            "id": "person_1",
+            "identitetsnummer": {
+              "idType": "FOEDSELSNUMMER",
+              "verdi": "22918197881"
+            },
             "kjoenn": "MANN",
             "foedselsdato": "1999-01-12",
             "plasseringKjoeretoey": "FOERERPLASS",

--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
@@ -537,6 +537,10 @@
       "type": "object",
       "description": "Informasjon om person involvert i ulykken",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Gjør personen unikt identifiserbar innad i saken, må være lik ved oppdateringsmelding."
+        },
         "identitetsnummer": {
           "$ref": "#/definitions/personIdentifikator",
           "description": "Fødselsnummer eller D-nummer. Vil alltid komme med om politiet har informasjon. Vil mangle ved feks utenlandsk statsborger"

--- a/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
+++ b/kontrakter/vegtrafikkulykke/trafikkulykke/1.0/trafikkulykke.schema.json
@@ -537,9 +537,9 @@
       "type": "object",
       "description": "Informasjon om person involvert i ulykken",
       "properties": {
-        "id": {
-          "type": "string",
-          "description": "Gjør personen unikt identifiserbar innad i saken, må være lik ved oppdateringsmelding."
+        "identitetsnummer": {
+          "$ref": "#/definitions/personIdentifikator",
+          "description": "Fødselsnummer eller D-nummer. Vil alltid komme med om politiet har informasjon. Vil mangle ved feks utenlandsk statsborger"
         },
         "kjoenn": {
           "type": "string",
@@ -574,7 +574,7 @@
           "type": "string"
         }
       },
-      "required": ["id", "beskyttelsesutstyr"],
+      "required": ["beskyttelsesutstyr"],
       "additionalProperties": false
     },
     "stedfesting": {
@@ -967,6 +967,27 @@
         "ZW"
       ],
       "description": "Hvilket land bil er registrert i. Verdier er FN sin liste over landkoder på biler https://www.unece.org/fileadmin/DAM/trans/conventn/Distsigns.pdf"
+    },
+    "personIdentifikator": {
+      "type": "object",
+      "description": "Fødselsnummer (inkl. Tenor) eller DNummer (inkl Tenor) som alle validerer til Modulus 11",
+      "properties": {
+        "idType": { "$ref": "#/definitions/personIdType" },
+        "verdi": {
+          "type": "string",
+          "description": "Se skatteetaten. Kan være vanlig med 6 sifret fødselsdato og fiktivt (Tenor) fødselsnummer med +80 på måned slik at noen født 10.01.1990 begynner fiktivt nummer med 108190",
+          "pattern": "^[0-7][0-9][012389][0-9]+$",
+          "minLength": 11,
+          "maxLength": 11
+        }
+      },
+      "required": ["idType", "verdi"],
+      "additionalProperties": false
+    },
+    "personIdType": {
+      "type": "string",
+      "description": "FNR eller DNR",
+      "enum": ["FOEDSELSNUMMER", "DNUMMER"]
     }
   }
 }


### PR DESCRIPTION
Vi sender med identitetsnummer om vi har det og om det er FNR/DNR. Eks ved en utenlandsk statsborger kan det være at identitetsnummer ikke er satt