### PR TITLE
Lagt til støtte for fengslingssurrugat i kjennelse (STRAFF2-1238)

### DIFF
--- a/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/KjennelseVaretekt.schema.json
+++ b/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/KjennelseVaretekt.schema.json
@@ -96,20 +96,19 @@
         "avgjoerelseResultat": {
           "$ref": "#/definitions/avgjoerelseResultat"
         },
-        "restriksjoner": {
+        "vilkaar": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/restriksjon"
-          }
-        },
-        "isolasjonsKrav": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/isolasjon"
-          }
+            "$ref": "#/definitions/vilkaar"
+          },
+          "minItems": 0,
+          "description": "Vilkårene listet enkeltvis. Disse er sammenstilt i lovbudStreng"
         },
         "fengsling": {
           "$ref": "#/definitions/fengsling"
+        },
+        "fengslingssurrogat": {
+          "$ref": "#/definitions/fengslingssurrogat"
         },
         "erklaering": {
           "$ref": "#/definitions/erklaering",
@@ -121,9 +120,7 @@
         "avsagtDato",
         "opprinneligKravid",
         "avgjoerelseResultat",
-        "fengsling",
-        "restriksjoner",
-        "isolasjonsKrav",
+        "vilkaar",
         "erklaering"
       ],
       "type": "object",
@@ -144,19 +141,51 @@
         "fengslingsFristDato": {
           "$ref": "#/definitions/dato"
         },
-        "vilkaar": {
+        "restriksjoner": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/vilkaar"
-          },
-          "description": "Vilkårene listet enkeltvis. Disse er sammenstilt i lovbudStreng"
+            "$ref": "#/definitions/restriksjon"
+          }
+        },
+        "isolasjonsKrav": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/isolasjon"
+          }
         },
         "merknad": {
           "type": "string",
           "description": "Merknad til fengslingen"
         }
       },
-      "required": ["fengslingsId", "vilkaar"],
+      "required": [
+        "fengslingsId",
+        "fraDato",
+        "tilDato",
+        "restriksjoner",
+        "isolasjonsKrav"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "fengslingssurrogat": {
+      "properties": {
+        "surrogatId": {
+          "type": "string",
+          "description": "surrogatId som opprettes i DA (GUID)"
+        },
+        "fraDato": {
+          "$ref": "#/definitions/dato"
+        },
+        "tilDato": {
+          "$ref": "#/definitions/dato"
+        },
+        "surrogatBeskrivelse": {
+          "type": "string",
+          "description": "Beskrivelse av fengslingssurrogatet"
+        }
+      },
+      "required": ["surrogatId", "fraDato", "tilDato", "surrogatBeskrivelse"],
       "type": "object",
       "additionalProperties": false
     },
@@ -291,13 +320,7 @@
     },
     "avgjoerelseResultat": {
       "description": "ANKEN_FORKASTES og OPPHEVELSE kun relevant i ankesaker",
-      "enum": [
-        "FENGSLING",
-        "LOESLATELSE",
-        "FENGSLINGSSURROGAT",
-        "ANKEN_FORKASTES",
-        "OPPHEVELSE"
-      ],
+      "enum": ["VARETEKT", "LOESLATELSE", "ANKEN_FORKASTES", "OPPHEVELSE"],
       "type": "string"
     },
     "rettsInstansType": {

--- a/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengsling.json
+++ b/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengsling.json
@@ -74,27 +74,19 @@
       "avsagtDato": "2022-07-05",
       "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
       "opprinneligKravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
-      "avgjoerelseResultat": "FENGSLING",
-      "restriksjoner": [
+      "avgjoerelseResultat": "VARETEKT",
+      "vilkaar": [
         {
-          "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
-          "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
-          "fraDato": "2022-07-06",
-          "tilDato": "2022-07-20"
+          "type": "STRPL170A_FORHOLSMESSIGHET",
+          "lovbudEnkel": {
+            "lovbudStreng": "Strpl §170 a.: Forholdsmessighet"
+          }
         },
         {
-          "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
-          "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
-          "fraDato": "2022-07-21",
-          "tilDato": "2022-08-06"
-        }
-      ],
-      "isolasjonsKrav": [
-        {
-          "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
-          "isolasjonsType": "FULL",
-          "fraDato": "2022-07-06",
-          "tilDato": "2022-08-06"
+          "type": "STRPL171_1_UNNDRAGELSESFARE",
+          "lovbudEnkel": {
+            "lovbudStreng": "Strpl §171.1: Unndragelsesfare"
+          }
         }
       ],
       "fengsling": {
@@ -102,18 +94,26 @@
         "fraDato": "2022-07-06",
         "tilDato": "2022-08-06",
         "fengslingsFristDato": "2022-07-06",
-        "vilkaar": [
+        "restriksjoner": [
           {
-            "type": "STRPL170A_FORHOLSMESSIGHET",
-            "lovbudEnkel": {
-              "lovbudStreng": "Strpl §170 a.: Forholdsmessighet"
-            }
+            "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
+            "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
+            "fraDato": "2022-07-06",
+            "tilDato": "2022-07-20"
           },
           {
-            "type": "STRPL171_1_UNNDRAGELSESFARE",
-            "lovbudEnkel": {
-              "lovbudStreng": "Strpl §171.1: Unndragelsesfare"
-            }
+            "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
+            "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
+            "fraDato": "2022-07-21",
+            "tilDato": "2022-08-06"
+          }
+        ],
+        "isolasjonsKrav": [
+          {
+            "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
+            "isolasjonsType": "FULL",
+            "fraDato": "2022-07-06",
+            "tilDato": "2022-08-06"
           }
         ],
         "merknad": "Kiwi må i varetekt så fort som fy"

--- a/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengslingOgSurrugat.json
+++ b/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengslingOgSurrugat.json
@@ -41,6 +41,7 @@
     "tilleggsId": [],
     "fornavn": "Morsom",
     "etternavn": "Kivi",
+    "kjoenn": "MANN",
     "foedselsdato": "1963-04-14",
     "nasjonalitet": {
       "kode": "NOR",
@@ -70,10 +71,10 @@
     "rettsmoeteTidTil": "2022-07-06T14:00:00+02:00",
     "avgjoerelse": {
       "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
+      "avsagtDato": "2022-07-05",
       "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
       "opprinneligKravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
       "avgjoerelseResultat": "VARETEKT",
-      "avsagtDato": "2022-07-05",
       "vilkaar": [
         {
           "type": "STRPL170A_FORHOLSMESSIGHET",
@@ -91,27 +92,42 @@
       "fengsling": {
         "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888",
         "fraDato": "2022-07-06",
-        "tilDato": "2022-08-06",
-        "fengslingsFristDato": "2022-07-06",
-        "restriksjoner": [],
+        "tilDato": "2022-07-20",
+        "fengslingsFristDato": "2022-08-06",
+        "restriksjoner": [
+          {
+            "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
+            "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
+            "fraDato": "2022-07-06",
+            "tilDato": "2022-07-12"
+          },
+          {
+            "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
+            "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
+            "fraDato": "2022-07-13",
+            "tilDato": "2022-07-20"
+          }
+        ],
         "isolasjonsKrav": [
           {
             "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
             "isolasjonsType": "FULL",
             "fraDato": "2022-07-06",
-            "tilDato": "2022-08-06"
+            "tilDato": "2022-07-12"
           }
         ],
         "merknad": "Kiwi må i varetekt så fort som fy"
       },
+      "fengslingssurrogat": {
+        "surrogatId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888",
+        "fraDato": "2022-07-21",
+        "tilDato": "2022-08-06",
+        "surrogatBeskrivelse": "Meldeplikt: Kiwi må melde seg på politistasjonen klokken 09:00 hver dag"
+      },
       "erklaering": {
         "erklaeringSiktede": {
           "meddeltIRettsmoete": true,
-          "erklaert": "ANKET",
-          "ankeDetaljer": {
-            "anketDato": "2022-07-06",
-            "ankedeForhold": ["FENGSLING", "FULL_ISOLASJON"]
-          }
+          "erklaert": "BETENKNINGSTID"
         },
         "erklaeringPaatale": {
           "meddeltIRettsmoete": true,

--- a/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengsling_anke.json
+++ b/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengsling_anke.json
@@ -71,28 +71,28 @@
       "avgjoerelseIdForrigeInstans": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
       "avsagtDato": "2022-07-05",
       "opprinneligKravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
-      "avgjoerelseResultat": "FENGSLING",
-      "restriksjoner": [],
-      "isolasjonsKrav": [],
+      "avgjoerelseResultat": "VARETEKT",
+      "vilkaar": [
+        {
+          "type": "STRPL170A_FORHOLSMESSIGHET",
+          "lovbudEnkel": {
+            "lovbudStreng": "Strpl §170 a.: Forholdsmessighet"
+          }
+        },
+        {
+          "type": "STRPL171_2_BEVISFORSPILLELSE",
+          "lovbudEnkel": {
+            "lovbudStreng": "Strpl §171.2: Bevisforspillelsesfare"
+          }
+        }
+      ],
       "fengsling": {
         "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1899",
         "fraDato": "2022-07-06",
         "tilDato": "2022-08-06",
         "fengslingsFristDato": "2022-07-06",
-        "vilkaar": [
-          {
-            "type": "STRPL170A_FORHOLSMESSIGHET",
-            "lovbudEnkel": {
-              "lovbudStreng": "Strpl §170 a.: Forholdsmessighet"
-            }
-          },
-          {
-            "type": "STRPL171_2_BEVISFORSPILLELSE",
-            "lovbudEnkel": {
-              "lovbudStreng": "Strpl §171.2: Bevisforspillelsesfare"
-            }
-          }
-        ],
+        "restriksjoner": [],
+        "isolasjonsKrav": [],
         "merknad": "Anke tas til følge og Kiwi må i fengsel"
       },
       "erklaering": {

--- a/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengsling_ingen_fengsling_anket.json
+++ b/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengsling_ingen_fengsling_anket.json
@@ -74,12 +74,7 @@
       "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
       "opprinneligKravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
       "avgjoerelseResultat": "LOESLATELSE",
-      "restriksjoner": [],
-      "isolasjonsKrav": [],
-      "fengsling": {
-        "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888",
-        "vilkaar": []
-      },
+      "vilkaar": [],
       "erklaering": {
         "erklaeringSiktede": {
           "meddeltIRettsmoete": true,

--- a/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengsling_restriksjoner.json
+++ b/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengsling_restriksjoner.json
@@ -73,41 +73,41 @@
       "avsagtDato": "2022-07-05",
       "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
       "opprinneligKravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
-      "avgjoerelseResultat": "FENGSLING",
-      "restriksjoner": [
+      "avgjoerelseResultat": "VARETEKT",
+      "vilkaar": [
         {
-          "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
-          "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
-          "fraDato": "2022-07-06",
-          "tilDato": "2022-07-20"
+          "type": "STRPL170A_FORHOLSMESSIGHET",
+          "lovbudEnkel": {
+            "lovbudStreng": "Strpl §170 a.: Forholdsmessighet"
+          }
         },
         {
-          "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
-          "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
-          "fraDato": "2022-07-21",
-          "tilDato": "2022-08-06"
+          "type": "STRPL171_1_UNNDRAGELSESFARE",
+          "lovbudEnkel": {
+            "lovbudStreng": "Strpl §171.1: Unndragelsesfare"
+          }
         }
       ],
-      "isolasjonsKrav": [],
       "fengsling": {
         "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888",
         "fraDato": "2022-07-06",
         "tilDato": "2022-08-06",
         "fengslingsFristDato": "2022-07-06",
-        "vilkaar": [
+        "restriksjoner": [
           {
-            "type": "STRPL170A_FORHOLSMESSIGHET",
-            "lovbudEnkel": {
-              "lovbudStreng": "Strpl §170 a.: Forholdsmessighet"
-            }
+            "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
+            "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
+            "fraDato": "2022-07-06",
+            "tilDato": "2022-07-20"
           },
           {
-            "type": "STRPL171_1_UNNDRAGELSESFARE",
-            "lovbudEnkel": {
-              "lovbudStreng": "Strpl §171.1: Unndragelsesfare"
-            }
+            "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
+            "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
+            "fraDato": "2022-07-21",
+            "tilDato": "2022-08-06"
           }
         ],
+        "isolasjonsKrav": [],
         "merknad": "Kiwi må i varetekt så fort som fy"
       },
       "erklaering": {

--- a/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengsling_uten_rettsmoete.json
+++ b/kontrakter/varetekt/kjennelseVaretekt/arbeidsversjon/eksempelfiler/eksempel_kjennelseVaretektsfengsling_uten_rettsmoete.json
@@ -72,27 +72,19 @@
       "avsagtDato": "2022-07-05",
       "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
       "opprinneligKravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
-      "avgjoerelseResultat": "FENGSLING",
-      "restriksjoner": [
+      "avgjoerelseResultat": "VARETEKT",
+      "vilkaar": [
         {
-          "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
-          "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
-          "fraDato": "2022-07-06",
-          "tilDato": "2022-07-20"
+          "type": "STRPL170A_FORHOLSMESSIGHET",
+          "lovbudEnkel": {
+            "lovbudStreng": "Strpl §170 a.: Forholdsmessighet"
+          }
         },
         {
-          "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
-          "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
-          "fraDato": "2022-07-21",
-          "tilDato": "2022-08-06"
-        }
-      ],
-      "isolasjonsKrav": [
-        {
-          "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
-          "isolasjonsType": "FULL",
-          "fraDato": "2022-07-06",
-          "tilDato": "2022-08-06"
+          "type": "STRPL171_1_UNNDRAGELSESFARE",
+          "lovbudEnkel": {
+            "lovbudStreng": "Strpl §171.1: Unndragelsesfare"
+          }
         }
       ],
       "fengsling": {
@@ -100,18 +92,26 @@
         "fraDato": "2022-07-06",
         "tilDato": "2022-08-06",
         "fengslingsFristDato": "2022-07-06",
-        "vilkaar": [
+        "restriksjoner": [
           {
-            "type": "STRPL170A_FORHOLSMESSIGHET",
-            "lovbudEnkel": {
-              "lovbudStreng": "Strpl §170 a.: Forholdsmessighet"
-            }
+            "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
+            "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
+            "fraDato": "2022-07-06",
+            "tilDato": "2022-07-20"
           },
           {
-            "type": "STRPL171_1_UNNDRAGELSESFARE",
-            "lovbudEnkel": {
-              "lovbudStreng": "Strpl §171.1: Unndragelsesfare"
-            }
+            "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
+            "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
+            "fraDato": "2022-07-21",
+            "tilDato": "2022-08-06"
+          }
+        ],
+        "isolasjonsKrav": [
+          {
+            "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
+            "isolasjonsType": "FULL",
+            "fraDato": "2022-07-06",
+            "tilDato": "2022-08-06"
           }
         ],
         "merknad": "Kiwi må i varetekt så fort som fy"


### PR DESCRIPTION
Forslag til kontraktsendringer for å støtte fengslingssurrugat:
* Lagt til nytt element 'fengslingssurrugat' på samme nivå som 'fengsling'
* 'fengsling' er nå optional da 'fengslingssurrugat' også kan velges
* flyttet 'lovbud' (også kalt vilkår), ut av 'fengsling' og ett nivå opp da de samme vilkårene gjelder for 'fengslingssurrugat'
* endret 'avgjoerelseResultat' enumen "fengsling" til "varetekt" slik at den kan brukes både for fengsling og surrogat
* Flyttet 'restriksjoner' og 'isolasjonsKrav' innunder 'fengsling' da de kun hører hjemme her