### PR TITLE
Fiks av typo i noen siktelsetyper

### DIFF
--- a/kontrakter/siktelseTiltale/1.0/siktelseTiltale.schema.json
+++ b/kontrakter/siktelseTiltale/1.0/siktelseTiltale.schema.json
@@ -427,8 +427,8 @@
         "SIKTELSE",
         "TILTALE",
         "FORELEGG",
-        "TILLEGSSIKTELSE",
-        "TILLEGSTILTALE",
+        "TILLEGGSSIKTELSE",
+        "TILLEGGSTILTALE",
         "PAAGRIPELSE_BESLUTNING"
       ]
     },

--- a/kontrakter/siktelseTiltale/arbeidsversjon/siktelseTiltale.schema.json
+++ b/kontrakter/siktelseTiltale/arbeidsversjon/siktelseTiltale.schema.json
@@ -427,8 +427,8 @@
         "SIKTELSE",
         "TILTALE",
         "FORELEGG",
-        "TILLEGSSIKTELSE",
-        "TILLEGSTILTALE",
+        "TILLEGGSSIKTELSE",
+        "TILLEGGSTILTALE",
         "PAAGRIPELSE_BESLUTNING"
       ]
     },


### PR DESCRIPTION
To typos i enum for siktelsestype er fikset.