### PR TITLE
Pakke av meldinger

### DIFF
--- a/kontrakter/dom/begjaeringDom/arbeidsversjon/begjaeringDom.schema.json
+++ b/kontrakter/dom/begjaeringDom/arbeidsversjon/begjaeringDom.schema.json
@@ -9,9 +9,9 @@
       "$ref": "#/definitions/forsendelse",
       "description": "avsender og mottaker"
     },
-    "pakke": {
-      "$ref": "#/definitions/pakke",
-      "description": "Pakke for å anngi flere meldinger som henger sammen."
+    "pakkeId": {
+      "$ref": "#/definitions/GUID",
+      "description": "Hvis meldingen sendes sammen med flere f.eks. siktelse og påstand om straff så vil alle de 3 meldingene ha samme pakke id."
     },
     "begjaeringDom": {
       "$ref": "#/definitions/begjaeringDom"
@@ -210,21 +210,6 @@
         "mottakerOrganisasjon",
         "sendtTid"
       ],
-      "additionalProperties": false
-    },
-    "pakke": {
-      "type": "object",
-      "description": "Denne meldingen sendes sammen med flere",
-      "properties": {
-        "pakkeId": { "$ref": "#/definitions/GUID" },
-        "meldinger": {
-          "type": "array",
-          "description": "Liste over meldingstyper som vil bli sendt",
-          "items": { "type": "string" },
-          "minItems": 2
-        }
-      },
-      "required": ["pakkeId", "meldinger"],
       "additionalProperties": false
     },
     "avsender": {

--- a/kontrakter/dom/begjaeringDom/arbeidsversjon/begjaeringDom.schema.json
+++ b/kontrakter/dom/begjaeringDom/arbeidsversjon/begjaeringDom.schema.json
@@ -9,6 +9,10 @@
       "$ref": "#/definitions/forsendelse",
       "description": "avsender og mottaker"
     },
+    "pakke": {
+      "$ref": "#/definitions/pakke",
+      "description": "Pakke for å anngi flere meldinger som henger sammen."
+    },
     "begjaeringDom": {
       "$ref": "#/definitions/begjaeringDom"
     },
@@ -206,6 +210,21 @@
         "mottakerOrganisasjon",
         "sendtTid"
       ],
+      "additionalProperties": false
+    },
+    "pakke": {
+      "type": "object",
+      "description": "Denne meldingen sendes sammen med flere",
+      "properties": {
+        "pakkeId": { "$ref": "#/definitions/GUID" },
+        "meldinger": {
+          "type": "array",
+          "description": "Liste over meldingstyper som vil bli sendt",
+          "items": { "type": "string" },
+          "minItems": 2
+        }
+      },
+      "required": ["pakkeId", "meldinger"],
       "additionalProperties": false
     },
     "avsender": {

--- a/kontrakter/dom/begjaeringDom/arbeidsversjon/eksempelfiler/begjaeringDom-eksempel-1.json
+++ b/kontrakter/dom/begjaeringDom/arbeidsversjon/eksempelfiler/begjaeringDom-eksempel-1.json
@@ -23,6 +23,14 @@
       "navn": "Agder tingrett"
     }
   },
+  "pakke": {
+    "pakkeId": "CADC75FC-22EF-478E-B4EC-27C49F85FD70",
+    "meldinger": [
+      "https://politiet.no/dom/arbeidsversjon/begjaeringDom",
+      "https://politiet.no/1.0/siktelseTiltale",
+      "https://domstol.no/dom/1.0/paastandStraff"
+    ]
+  },
   "begjaeringDom": {
     "kravId": "715ED997-479E-4791-A475-5F906341C33E",
     "begjaeringstype": "TILSTAAELSE",

--- a/kontrakter/dom/begjaeringDom/arbeidsversjon/eksempelfiler/begjaeringDom-eksempel-1.json
+++ b/kontrakter/dom/begjaeringDom/arbeidsversjon/eksempelfiler/begjaeringDom-eksempel-1.json
@@ -23,14 +23,8 @@
       "navn": "Agder tingrett"
     }
   },
-  "pakke": {
-    "pakkeId": "CADC75FC-22EF-478E-B4EC-27C49F85FD70",
-    "meldinger": [
-      "https://politiet.no/dom/arbeidsversjon/begjaeringDom",
-      "https://politiet.no/1.0/siktelseTiltale",
-      "https://domstol.no/dom/1.0/paastandStraff"
-    ]
-  },
+
+  "pakkeId": "CADC75FC-22EF-478E-B4EC-27C49F85FD70",
   "begjaeringDom": {
     "kravId": "715ED997-479E-4791-A475-5F906341C33E",
     "begjaeringstype": "TILSTAAELSE",

--- a/kontrakter/dom/begjaeringDom/changelog.md
+++ b/kontrakter/dom/begjaeringDom/changelog.md
@@ -1,11 +1,15 @@
 # Endringslogg begjæring om dom
 
-| Versjon | Beskrivelse | Aktiv fra | Aktiv til |
-|---------|-------------|-----------|-----------|
-| 1.0     | test        |           |           |
+| Versjon | Beskrivelse                                   | Aktiv fra | Aktiv til |
+|---------|-----------------------------------------------|-----------|-----------|
+|arbeidsversjon | pakkeId for flere meldinger som hører sammen  | |           |
+| 1.0     | test                                          |           |           |
 
+## arbeidsversjon korrigering av begjæring
+Vi trenger en måte å koble sammen meldinger som hører sammen.
+Vi vil sende meldingene med samme pakke id.
+Ved korrigering av begjæring så vil vi sende begjaeringDom, paastandStraff og siktelseTiltale på nytt.
 ## Versjon 1.0 er låst begynner med arbeidsversjon for endringer
-
 ### 17.02.2025 Korrigering av begjæring av dom
 Endres i arbeidsversjon først, blir versjon 1.1.
 Lager pakke med referanse til alle andre meldingstyper.

--- a/kontrakter/dom/begjaeringDom/changelog.md
+++ b/kontrakter/dom/begjaeringDom/changelog.md
@@ -6,6 +6,9 @@
 
 ## Versjon 1.0 er låst begynner med arbeidsversjon for endringer
 
+### 17.02.2025 Korrigering av begjæring av dom
+Endres i arbeidsversjon først, blir versjon 1.1.
+Lager pakke med referanse til alle andre meldingstyper.
 ### 23.09.2024 Fornærmede med kobling til straffesak
 SiktelseTiltale er kun med siktede så fornærmede i begjæringDom må inneholde kobling til hvilken straffesak de er fornærmet i (som vitner).
 ### 18.09.2024 en siktet person


### PR DESCRIPTION
Fra jira sak ESAS-1771
Begjæring om dom (begjaeringDom), påstand om straff (paastandStraff) og siktelse (siktelseTiltale) sendes alle sammen nesten samtidig.
Når domstolene mottar en begjæring så skal de vite hvilke meldinger som kommer sammen og det bør være eksplisitt i alle meldingene da rekkefølgene på mottaket ikke er definert.

Endring kun på begjaringDom meldingen nå. Når vi har en løsning alle kan leve med så utvider vi alle meldinger som skal kunne sendes som en pakke.