### PR TITLE
Arrestordreloven og flere andre mulig valg som grunnlag varetekt

### DIFF
--- a/kontrakter/varetekt/begjaeringVaretekt/arbeidsversjon/begjaeringVaretekt.schema.json
+++ b/kontrakter/varetekt/begjaeringVaretekt/arbeidsversjon/begjaeringVaretekt.schema.json
@@ -271,7 +271,7 @@
     },
     "spraakkodeType": {
       "description": "En spraakkode bestaar av tre store bokstaver fra kodelisten ISO 639-3 som representerer spraak",
-      "pattern": "^([A-Z]{3,3})$",
+      "pattern": "^([A-Z]{3})$",
       "type": "string"
     },
     "behovForTolkType": {
@@ -348,10 +348,19 @@
         "STRPL171_3_GJENTAGELSESFARE",
         "STRPL171_4_FYLDESTGJOERENDE_GRUNNER",
         "STRPL172_A_10_AAR",
+        "ARRESTORDREL13",
+        "ARRESTORDREL20",
+        "ARRESTORDREL38",
+        "STRPL88_UTEBLIVELSE",
+        "STRPL171_MINDRE_TYVERI",
+        "STRPL171_MULIG_SAARREAKSJON",
         "STRPL172_B_GROV_VOLD",
+        "STRPL173_FLUKT_TIL_UTLENDET",
         "STRPL173A_A_UNNDRAGELSESFARE_VILK",
         "STRPL173A_B_HINDRE_VILK",
-        "STRPL173A_C_BEGJAERT_SIKTEDE"
+        "STRPL173A_C_BEGJAERT_SIKTEDE",
+        "STRPL187_ANKE_ETTER_FRIFINNELSE",
+        "ANNEN_SPESIALBESTEMMELSE"
       ]
     },
     "vilkaar": {

--- a/kontrakter/varetekt/begjaeringVaretekt/changelog.md
+++ b/kontrakter/varetekt/begjaeringVaretekt/changelog.md
@@ -1,36 +1,30 @@
 # Endringslogg begjæring om varetek
 
-| Versjon | Beskrivelse                                 | Aktiv mottaker | Aktiv sender | Aktiv til   |
-|---------|---------------------------------------------|----------------|--------------|-------------|
-| 1.4     | Kunne begjære varetektsfengsling frem i tid | 20.03.2024     | 25.03.2024   |             |
-| 1.3     | Håndter vitner uten identifikator           | ??             |              | 20.03.2024  |
-| 1.2     | Første versjon til produksjon, pilot        | 09.10.2023     |              |             |
-| 1.1     | Tolk og til hovedforhandling                | 01.08.2023     |              | 09.10.2023  |
-| 1.0     | Brukertest juni 2023, ikke til produksjon   |                |              | 01.08.2023  |
+| Versjon | Beskrivelse                                 | Aktiv mottaker | Aktiv sender | 
+|---------|---------------------------------------------|----------------|--------------|
+| arbeidsversjon| Arrestordreloven/surrogat                   |  |
+| 1.4     | Kunne begjære varetektsfengsling frem i tid | 20.03.2024     | 25.03.2024   |
+| 1.3     | Håndter vitner uten identifikator           | ??             |              |
+| 1.2     | Første versjon til produksjon, pilot        | 09.10.2023     |              |
+| 1.1     | Tolk og til hovedforhandling                | 01.08.2023     |              |
+| 1.0     | Brukertest juni 2023, ikke til produksjon   |                |              |
 
+## Versjon 1.5 arrestordreloven og surrogat
+ESAS-1396 og ESAS-476
+Jobber i arbeidsversjon til endringene er godkjent.
 ## Versjon 1.4 - i produksjon
-
 ### Begjæring om varetekt gyldig fra 
-
 Dersom det begjæres om varetekt frem i tid er det lagt til et felt gyldigFraDato i paastandVaretekt som sier når begjæringen skal gjelde fra.
-
 ## Versjon 1.3
-
 ### Fødselsdato på vitner er optional
-
 Fødselsdato for vitner er gjort optional. Dette er noe vi mangler for enkelte, ofte når vitner er politi. 
-
 ## Versjon 1.2
-
 ### Fengsling utløper dato ved forlengelse
-
 Det er lagt til dato for når forrige/gjeldene fengsling utløper under forlengelseInfo ved begjæring om varetekt forlengelse
-
 Andre del av endringer fra brukertest til pilot, planlagte endringer:
 1. Forsvareroppnevning
 2. Fengslingssurrogater (?)
 3. ... 
-
 ## Versjon 1.1 - første del av oppdateringer etter brukertest
 
 ### Oppdatert begrense offentlighet


### PR DESCRIPTION
Nå er det samme listen som ny kjennelse: https://github.com/domstolene/ESAS/pull/270 
Politiet vil ikke begynne å bruke ANNEN_SPESIALBESTEMMELSE før det blir meldt som et behov