### PR TITLE
besluttetAv, domstol 

### DIFF
--- a/kontrakter/dom/fullbyrdelsesordre/arbeidsversjon/eksempelfiler/fullbyrdelsesordre-eksempel-1.json
+++ b/kontrakter/dom/fullbyrdelsesordre/arbeidsversjon/eksempelfiler/fullbyrdelsesordre-eksempel-1.json
@@ -1,0 +1,198 @@
+{
+  "forsendelse": {
+    "meldingsId": "f449FBad-AF5C-C40C-7DE5-BfafD382CDd0",
+    "sendtTid": "1892-06-30T19:21:41.0Z",
+    "avsender": {
+      "organisasjon": {
+        "organisasjonsnummer": "983997953",
+        "navn": "Innlandet politidistrikt"
+      },
+      "person": {
+        "navn": {
+          "etternavn": "Gunnarsen",
+          "fornavn": "Gunnar"
+        },
+        "tittel": "Konsulent",
+        "kontakt": {
+          "epost": "gunnar.gunnarsen@politi.no"
+        }
+      }
+    },
+    "mottakerOrganisasjon": {
+      "organisasjonsnummer": "983997953",
+      "navn": "Kriminalomsorgen"
+    }
+  },
+  "under18": false,
+  "fullbyrdelsesordre": {
+    "anmodningsId": "f449FBad-AF5C-C40C-7DE5-BfafD382CDd1",
+    "paataleansvarlig": {
+      "navn": {
+        "etternavn": "Klausonius",
+        "fornavn": "Lars"
+      },
+      "tittel": "Påtaleansvarlig",
+      "kontakt": {
+        "epost": "lars.klausonius@politiet.no",
+        "telefonnummer": ["0047 97 97 97 97"]
+      }
+    },
+    "besluttetAv": {
+      "navn": {
+        "etternavn": "Klausonius",
+        "fornavn": "Lars"
+      },
+      "tittel": "Politiadvokat"
+    },
+    "domfelte": {
+      "person": {
+        "personForetakRef": "f449FBad-AF5C-C40C-7DE5-BfafD382CDd0",
+        "navn": {
+          "etternavn": "Skurkesen",
+          "fornavn": "Ronald"
+        },
+        "foedselsdato": "1896-05-10",
+        "kjoenn": "MANN",
+        "statsborgerskap": [
+          {
+            "kode": "NOR",
+            "navn": "Norge"
+          }
+        ],
+        "identitetsnummer": {
+          "idType": "FOEDSELSNUMMER",
+          "verdi": "07099715094"
+        },
+        "tilleggsId": []
+      },
+      "personAdresse": {
+        "adresse": {
+          "adresselinjer": ["her er det veldig fint", "igjen"],
+          "postnummer": "3244",
+          "poststed": "Jålla",
+          "land": {
+            "kode": "NOR",
+            "navn": "Norge"
+          }
+        }
+      },
+      "kontaktInfo": {
+        "epost": "rart.tryne@jo.tt"
+      },
+      "verger": []
+    },
+    "avgjoerelse": {
+      "domstol": {
+        "organisasjonsnummer": "826726342",
+        "navn": "Buskerud tingrett"
+      },
+      "avgjoerelseId": "f449FBad-AF5C-C40C-7DE5-BfafD382CDd0",
+      "saksnummer": "24-113474ENE-TOSL/01",
+      "avsagtDato": "1957-11-25",
+      "straffesakDomsnummer": "D123/25-201",
+      "reaksjoner": {
+        "bot": {
+          "beloep": 24000,
+          "proevetid": {
+            "antallAar": 2
+          },
+          "subsidaerFengselsstraff": {
+            "antallDager": 24
+          }
+        },
+        "fengsel": {
+          "straff": {
+            "antallAar": 2,
+            "antallMaaneder": 4
+          },
+          "betinget": {
+            "antallMaaneder": 6
+          },
+          "proevetid": {
+            "antallAar": 2
+          },
+          "fradrag": {
+            "antallDager": 24
+          },
+          "saervilkaar": [
+            {
+              "paragraf": "§35",
+              "tekst": "Særvilkår om meldeplikt",
+              "beskrivelse": "Masse Kiwi skal melde seg til politiet én gang i måneden"
+            },
+            {
+              "paragraf": "§36",
+              "tekst": "Andre særvilkår",
+              "detaljer": "f. gjennomføre narkotikaprogram med domstolskontroll, jf. § 38,"
+            }
+          ]
+        }
+      },
+      "straffbareForhold": [
+        {
+          "basissakId": "1234121-123",
+          "lovbudKombinert": {
+            "lovbud": [
+              {
+                "lovbudId": "8d5e1fe3-a6e7-44e1-9c99-6ea140320375",
+                "lovbudStreng": "Straffeloven § 332",
+                "gjengivelse": "for å ha mottatt eller skaffet seg eller andre del i utbytte av en straffbar handling. Likestilt med utbytte er en gjenstand, fordring eller tjeneste som trer istedenfor det.",
+                "strafferamme": 24
+              }
+            ]
+          },
+          "straffesak": {
+            "straffesaksnummer": "12345678910",
+            "statistikkgruppe": {
+              "kode": "0960",
+              "navn": "Heleri"
+            },
+            "krimtype": {
+              "kode": "02",
+              "navn": "Vinningskriminalitet"
+            }
+          },
+          "fornaermede": [
+            {
+              "person": {
+                "personForetakRef": "f449FBad-AF5C-C40C-7DE5-BfafD382CDd0",
+                "navn": {
+                  "fornavn": "Linda",
+                  "mellomnavn": "Irene",
+                  "etternavn": "Moltubakk"
+                },
+                "foedselsdato": "1961-03-03",
+                "kjoenn": "KVINNE",
+                "statsborgerskap": [],
+                "identitetsnummer": {
+                  "idType": "FOEDSELSNUMMER",
+                  "verdi": "07099715094"
+                }
+              },
+              "verger": []
+            }
+          ]
+        }
+      ]
+    },
+    "foregrepetSoning": false,
+    "rettskraftigFraOgMed": "1944-05-18"
+  },
+  "beskrivelse": "Domfelte ønsker å sone så fort som mulig og er litt vanskelig å ha med å gjøre.",
+  "hovedStraffesaksnummer": "12345678910",
+  "dokumenter": [
+    {
+      "dokumentRef": "f449FBad-AF5C-C40C-7DE5-BfafD382CDd0",
+      "overskrift": "Vedlegg",
+      "skrevetDato": "2023-03-30",
+      "kategori": {
+        "kode": "siktelse"
+      },
+      "forsendelse": {
+        "mimeType": "application/pdf",
+        "uri": "file:///asdfasdf",
+        "sjekksum": "234s"
+      }
+    }
+  ]
+}

--- a/kontrakter/dom/fullbyrdelsesordre/arbeidsversjon/fullbyrdelsesordre.schema.json
+++ b/kontrakter/dom/fullbyrdelsesordre/arbeidsversjon/fullbyrdelsesordre.schema.json
@@ -1,0 +1,1031 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kriminalomsorgen.no/dom/arbeidsversjon/fullbyrdelsesordre",
+  "description": "Schema definisjon av en Fullbyrdelsesordre",
+  "type": "object",
+  "properties": {
+    "forsendelse": {
+      "description": "Avsender og mottaker",
+      "$ref": "#/definitions/forsendelse"
+    },
+    "under18": {
+      "type": "boolean",
+      "description": "Sant hvis siktede var under 18 år på en av gjerningstidspunktene som personen er skyldig i"
+    },
+    "fullbyrdelsesordre": {
+      "$ref": "#/definitions/fullbyrdelsesordre",
+      "description": "Selv ordren med detaljer fra dommen"
+    },
+    "beskrivelse": {
+      "type": "string",
+      "description": "Tilleggsinformasjon om fullbyrdelsen."
+    },
+    "hovedStraffesaksnummer": {
+      "$ref": "#/definitions/straffesaksnummer",
+      "description": "Hovedsaken i et sakskompleks, også saksbehandlersak."
+    },
+    "dokumenter": {
+      "type": "array",
+      "description": "Det vil alltid være minst 1 dokument som er dommen fra domstolen.",
+      "items": {
+        "$ref": "#/definitions/dokument"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "forsendelse",
+    "under18",
+    "fullbyrdelsesordre",
+    "dokumenter",
+    "beskrivelse",
+    "hovedStraffesaksnummer"
+  ],
+  "additionalProperties": false,
+
+  "definitions": {
+    "fullbyrdelsesordre": {
+      "type": "object",
+      "description": "Ordre med detaljer fra dommen, selve ordren utstedes i BL av påtalejurist",
+      "properties": {
+        "anmodningsId": {
+          "$ref": "#/definitions/GUID",
+          "description": "Unik nøkkel på oversendelse av ordre."
+        },
+        "paataleansvarlig": {
+          "$ref": "#/definitions/ansattPerson",
+          "description": "Ansvarlig påtalejurist på straffesaken, det kan være annen jurist som har beordret fullbyrdelse"
+        },
+        "besluttetAv": {
+          "$ref": "#/definitions/ansattPerson",
+          "description": "Jurist som har besluttet fullbyrdelse."
+        },
+        "domfelte": {
+          "$ref": "#/definitions/siktetPerson",
+          "description": "Person som er dømt og som skal til soning"
+        },
+        "avgjoerelse": {
+          "$ref": "#/definitions/avgjoerelse",
+          "description": "Dommen fra domstolene (kan være rettsbok)"
+        },
+        "foregrepetSoning": {
+          "type": "boolean",
+          "description": "Hvis person skal overføres til soning "
+        },
+        "rettskraftigFraOgMed": {
+          "$ref": "#/definitions/dato",
+          "description": "Det er påtale som setter når dommen er rettskraftig. Påbudt hvis det ikke er foregrepet soning"
+        }
+      },
+      "required": [
+        "anmodningsId",
+        "paataleansvarlig",
+        "besluttetAv",
+        "domfelte",
+        "avgjoerelse",
+        "foregrepetSoning"
+      ],
+      "if": {
+        "properties": {
+          "foregrepetSoning": { "const": false },
+          "rettskraftigFraOgMed": {
+            "$ref": "#/definitions/dato"
+          }
+        }
+      },
+      "then": {
+        "required": ["rettskraftigFraOgMed"]
+      },
+      "additionalProperties": false
+    },
+    "avgjoerelse": {
+      "type": "object",
+      "description": "Dommen fra domstolene, med struktur på reaksjoner som Kriminalomsorgen skal følge opp.",
+      "properties": {
+        "domstol": {
+          "$ref": "#/definitions/organisasjon"
+        },
+        "avgjoerelseId": {
+          "$ref": "#/definitions/GUID",
+          "description": "Domstolen sin id for avgjørelsen. Kan bli brukt i forbindelse med anke/forlengelse. AvgjørelseId beholdes ved korrigeringer"
+        },
+        "saksnummer": {
+          "type": "string",
+          "description": "Domstolen sitt interne saksnummer"
+        },
+        "avsagtDato": {
+          "$ref": "#/definitions/dato"
+        },
+        "straffesakDomsnummer": {
+          "type": "string",
+          "description": "Påtalemyndigheten sitt nummer/arkivnummer for dommen."
+        },
+        "reaksjoner": {
+          "description": "Reaksjoner for denne personen.",
+          "$ref": "#/definitions/reaksjonsType"
+        },
+        "straffbareForhold": {
+          "type": "array",
+          "description": "Alle lovbrudd dømte er funnet skyldig i. Lovreferanse og tilleggsinformasjon fra straffesaken (resultat i domsavgjoerelse)",
+          "items": {
+            "$ref": "#/definitions/straffbartForhold"
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "domstol",
+        "avgjoerelseId",
+        "saksnummer",
+        "avsagtDato",
+        "reaksjoner",
+        "straffbareForhold"
+      ],
+      "additionalProperties": false
+    },
+    "straffbartForhold": {
+      "type": "object",
+      "description": "Lovbudet med detaljer hvis det ikke er omsubsumert av domstolen, detaljer fra Straffesaken.",
+      "properties": {
+        "basissakId": {
+          "$ref": "#/definitions/unikId",
+          "description": "Unik id for basissak som er: En person/fortak, en straffbar handling, ett lovbud"
+        },
+        "lovbudKombinert": {
+          "$ref": "#/definitions/lovbudKombinert"
+        },
+        "straffesak": {
+          "$ref": "#/definitions/straffesak",
+          "description": "Koding av straffesaken"
+        },
+        "fornaermede": {
+          "description": "Fornærmede personer. Benyttes til f.eks varsling ved permisjoner etc.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/relatertPerson"
+          }
+        }
+      },
+      "required": ["lovbudKombinert", "straffesak", "fornaermede"]
+    },
+    "lovbudKombinert": {
+      "type": "object",
+      "description": "liste over lovbud hvis det straffbare forholdet har skjedde over en lovendring (kombinert)",
+      "properties": {
+        "lovbud": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/lovbudFull"
+          },
+          "minItems": 1,
+          "maxItems": 2
+        }
+      },
+      "required": ["lovbud"],
+      "additionalProperties": false
+    },
+    "lovbud": {
+      "type": "object",
+      "description": "Lovbud, kun lovbudstreng hvis domstolene har omsubsumert.",
+      "properties": {
+        "lovbudId": {
+          "$ref": "#/definitions/unikId"
+        },
+        "lovbudStreng": {
+          "$ref": "#/definitions/lovbudStreng",
+          "description": "Sammensatt hjemmelsrekke i en lang streng"
+        },
+        "gjengivelse": {
+          "type": "string"
+        },
+        "strafferamme": {
+          "type": "integer",
+          "description": "Antall måneder"
+        }
+      },
+      "required": ["lovbudStreng"],
+      "additionalProperties": false
+    },
+    "lovbudFull": {
+      "type": "object",
+      "description": "Full lovbudsstruktur. LovbudId fylt ut fra påtale. Kun lovbudstreng fylt ut hvis domstolene har omsubsumert.",
+      "properties": {
+        "lovbudId": {
+          "$ref": "#/definitions/unikId"
+        },
+        "lovbudStreng": {
+          "$ref": "#/definitions/lovbudStreng",
+          "description": "Sammensatt hjemmelsrekke i en lang streng"
+        },
+        "gjengivelse": {
+          "type": "string"
+        },
+        "grunnlagTekst": {
+          "type": "string",
+          "description": "Tekstlig beskrivelse av endringen, kan være lang tekst med mange linjeskift."
+        },
+        "strafferamme": {
+          "type": "integer",
+          "description": "Antall måneder"
+        },
+        "hjemler": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/hjemmel"
+          },
+          "minItems": 0
+        }
+      },
+      "required": ["lovbudStreng"],
+      "additionalProperties": false
+    },
+    "hjemmel": {
+      "type": "object",
+      "description": "Hjemmel bestående av rettskilde og elementer.",
+      "properties": {
+        "rettskilde": {
+          "$ref": "#/definitions/rettskilde"
+        },
+        "elementer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/hjemmelElement"
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["rettskilde", "elementer"],
+      "additionalProperties": false
+    },
+    "rettskilde": {
+      "type": "object",
+      "description": "Rettskilde. For eksempel 'Straffeloven'.",
+      "properties": {
+        "kode": {
+          "type": "string"
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["kode", "navn"],
+      "additionalProperties": false
+    },
+    "hjemmelElement": {
+      "type": "object",
+      "description": "Hjemmel-element. For eksempel PARAGRAF, LEDD, NR, ",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "verdi": {
+          "type": "string"
+        }
+      },
+      "required": ["type", "verdi"],
+      "additionalProperties": false
+    },
+    "straffesak": {
+      "type": "object",
+      "description": "Straffesak koding.",
+      "properties": {
+        "straffesaksnummer": {
+          "$ref": "#/definitions/straffesaksnummer"
+        },
+        "statistikkgruppe": {
+          "$ref": "#/definitions/kodeverk"
+        },
+        "krimtype": {
+          "$ref": "#/definitions/kodeverk"
+        }
+      },
+      "required": ["straffesaksnummer", "statistikkgruppe"],
+      "additionalProperties": false
+    },
+    "reaksjonsType": {
+      "properties": {
+        "fengsel": {
+          "$ref": "#/definitions/fengsel"
+        },
+        "bot": {
+          "$ref": "#/definitions/bot"
+        },
+        "samfunnsstraff": {
+          "$ref": "#/definitions/samfunnsstraff"
+        },
+        "ungdomsstraff": {
+          "$ref": "#/definitions/ungdomsstraff"
+        },
+        "rettighetstap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/rettighetstapDetaljer"
+          },
+          "minItems": 1
+        },
+        "rettighetstapMotorvogn": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/rettighetstapDetaljer"
+          },
+          "minItems": 1
+        },
+        "rettighetstapTransport": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/rettighetstapDetaljer"
+          },
+          "minItems": 1
+        },
+        "inndragning": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inndragning"
+          },
+          "minItems": 1
+        },
+        "annet": {
+          "$ref": "#/definitions/annet"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "fengsel": {
+      "properties": {
+        "straff": {
+          "$ref": "#/definitions/lengde",
+          "description": "Lengden på fengselsstraffen"
+        },
+        "betinget": {
+          "$ref": "#/definitions/lengde",
+          "description": "Fylles kun dersom deler eller hele straffen er betinget"
+        },
+        "proevetid": {
+          "$ref": "#/definitions/lengde"
+        },
+        "saervilkaar": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/saervilkaar"
+          },
+          "minItems": 0
+        },
+        "fradrag": {
+          "$ref": "#/definitions/lengde",
+          "description": "Fradrag for straffen (f.eks. tid i varetekt). Også kalt Utholdt frihetsberøvelse"
+        }
+      },
+      "required": ["straff"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "bot": {
+      "properties": {
+        "beloep": {
+          "type": "integer",
+          "description": "Nettobeløp i NOK",
+          "$comment": "Trenger vi støtte for andre valuta??"
+        },
+        "proevetid": {
+          "$ref": "#/definitions/lengde",
+          "description": "Kan settes dersom boten er betinget"
+        },
+        "saervilkaar": {
+          "description": "Kan settes dersom boten er betinget. Henvisning til §36 eller §37",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/saervilkaar"
+          },
+          "minItems": 0
+        },
+        "subsidaerFengselsstraff": {
+          "$ref": "#/definitions/lengde",
+          "description": "Lengden på subsidiær fengselsstraff"
+        }
+      },
+      "required": ["beloep"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "samfunnsstraff": {
+      "properties": {
+        "straff": {
+          "$ref": "#/definitions/lengde",
+          "description": "Lengden på idømt samfunnsstraff - som regel oppgitt i timer"
+        },
+        "gjennomfoeringstid": {
+          "$ref": "#/definitions/lengde",
+          "description": "Innen hvor lang tidsperiode straffen må gjennomføres. Som regel oppgitt i timer"
+        },
+        "subsidaerFengselsstraff": {
+          "$ref": "#/definitions/lengde",
+          "description": "Lengden på subsidiær fengselsstraff"
+        },
+        "fradrag": {
+          "$ref": "#/definitions/lengde",
+          "description": "Fradrag for straffen (f.eks. tid i varetekt). Også kalt Utholdt frihetsberøvelse"
+        },
+        "vilkaar": {
+          "type": "string",
+          "description": "Vilkår vedrørenede gjennomføring av straffen (jf. §50)"
+        }
+      },
+      "required": ["straff"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ungdomsstraff": {
+      "properties": {
+        "straff": {
+          "$ref": "#/definitions/lengde",
+          "description": "Lengden på idømt straff"
+        },
+        "subsidaerFengselsstraff": {
+          "$ref": "#/definitions/lengde",
+          "description": "Lengden på subsidiær fengselsstraff"
+        },
+        "fradrag": {
+          "$ref": "#/definitions/lengde",
+          "description": "Fradrag for straffen (f.eks. tid i varetekt). Også kalt Utholdt frihetsberøvelse"
+        }
+      },
+      "required": ["straff"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "rettighetstapDetaljer": {
+      "$comment": "Hva med tap av rett til å føre 'ikke førerkortpliktig motorvogn', eller ting man trenger kjøreseddel til (f.eks. buss taxi). Egen property eller en form for fritekst? Og burde vi ha med hvilken klasse?",
+      "properties": {
+        "hjemmel": {
+          "$ref": "#/definitions/lovbudStreng"
+        },
+        "varighet": {
+          "$ref": "#/definitions/varighet",
+          "$comment": "Kan/bør vi bruke tidsrom i stedet for/tillegg til varighet?"
+        },
+        "tekst": {
+          "type": "string",
+          "description": "Fritekst som beskriver rettighetstapet"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "inndragning": {
+      "properties": {
+        "hjemmel": {
+          "$ref": "#/definitions/lovbudStreng",
+          "description": "Type inndragning. Eks. '§ 67 Inndragning av utbytte', '§ 68 Utvidet inndragning' etc."
+        },
+        "beloep": {
+          "type": "integer",
+          "description": "Beløp i norske kroner"
+        },
+        "beskrivelse": {
+          "type": "string",
+          "description": "Beskrivelse av inndragningen"
+        },
+        "tilfaller": {
+          "type": "string",
+          "description": "Navn på person beløpet tilfaller. Ikke satt dersom beløpet tilfaller statskassen"
+        },
+        "alternativBelopForGjenstand": {
+          "type": "boolean",
+          "description": "Dersom inndragning dreier seg om type '§ 69 Inndragning av produkt' Kan man velge å sette alternativt belæp for gjenstand"
+        }
+      },
+      "required": ["hjemmel"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "annet": {
+      "properties": {
+        "tekst": {
+          "type": "string",
+          "description": "Fritekst som beskriver 'annet'-reaksjonen"
+        }
+      },
+      "required": ["tekst"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "varighet": {
+      "type": "object",
+      "description": "Definisjon på en varighet. F.eks. varighet på 'tap av rettighet'",
+      "properties": {
+        "lengde": { "$ref": "#/definitions/lengde" },
+        "ubestemtTid": { "type": "boolean" }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "lengde": { "$ref": "#/definitions/lengde" }
+          },
+          "required": ["lengde"]
+        },
+        {
+          "properties": {
+            "ubestemtTid": {
+              "type": "boolean"
+            }
+          },
+          "required": ["ubestemtTid"]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "lengde": {
+      "type": "object",
+      "properties": {
+        "antallAar": { "$ref": "#/definitions/aar" },
+        "antallMaaneder": { "$ref": "#/definitions/maaneder" },
+        "antallDager": { "$ref": "#/definitions/dager" },
+        "antallTimer": { "$ref": "#/definitions/timer" }
+      },
+      "additionalProperties": false
+    },
+    "periode": {
+      "type": "object",
+      "properties": {
+        "tidFra": {
+          "$ref": "#/definitions/datoTid"
+        },
+        "tidTil": {
+          "$ref": "#/definitions/datoTid"
+        }
+      },
+      "additionalProperties": false
+    },
+    "saervilkaar": {
+      "type": "object",
+      "properties": {
+        "paragraf": {
+          "type": "string",
+          "description": "Eks. '§37'"
+        },
+        "tekst": {
+          "type": "string",
+          "description": "Eks. Andre særvilkår'"
+        },
+        "detaljer": {
+          "type": "string",
+          "description": "Detaljer for særvilkåret. Fylles ut ved '§ 37.Andre særvilkår'"
+        },
+        "beskrivelse": {
+          "type": "string",
+          "description": "Brukerens egen beskrivelse av særvilkåret"
+        }
+      },
+      "required": ["paragraf", "tekst"],
+      "additionalProperties": false
+    },
+    "lovbudStreng": {
+      "type": "string",
+      "description": "Ingen kobling til lovbudserver, kun tekst f.eks. Vegtrafikkloven § 31 første ledd, jf. § 3"
+    },
+    "forsendelse": {
+      "type": "object",
+      "properties": {
+        "meldingsId": {
+          "$ref": "#/definitions/GUID",
+          "description": "Unik ID for denne meldingen, hvis siktelsen blir sendt på nytt vil det være ny meldingsId"
+        },
+        "sendtTid": { "$ref": "#/definitions/datoTid" },
+        "avsender": { "$ref": "#/definitions/avsender" },
+        "mottakerOrganisasjon": {
+          "$ref": "#/definitions/organisasjon",
+          "description": "Domstol som skal være mottaker"
+        }
+      },
+      "required": [
+        "meldingsId",
+        "avsender",
+        "mottakerOrganisasjon",
+        "sendtTid"
+      ],
+      "additionalProperties": false
+    },
+    "avsender": {
+      "type": "object",
+      "properties": {
+        "organisasjon": {
+          "$ref": "#/definitions/organisasjon"
+        },
+        "person": {
+          "$ref": "#/definitions/ansattPerson",
+          "description": "Person som trykker på send til domstolen."
+        }
+      },
+      "required": ["organisasjon", "person"],
+      "additionalProperties": false
+    },
+    "organisasjon": {
+      "type": "object",
+      "description": "Entydig identifikator av juridisk enhet. F.eks en spesifik domstol, embete eller politidistrikt",
+      "properties": {
+        "navn": {
+          "description": "F.eks. Oslo politidistikt, Riksadvokaten, Borgarting lagmannsrett",
+          "type": "string"
+        },
+        "organisasjonsnummer": {
+          "$ref": "#/definitions/organisasjonsnummer"
+        }
+      },
+      "required": ["organisasjonsnummer", "navn"],
+      "additionalProperties": false
+    },
+    "ansattPerson": {
+      "type": "object",
+      "description": "Saksbehandler, jurist etterforsker hos politiet, ansatte hos domstolene eller kriminalomsorgen",
+      "properties": {
+        "tittel": {
+          "type": "string"
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "kontakt": {
+          "$ref": "#/definitions/kontaktInfo",
+          "description": "Minimum epost adresse til den som sender melding. Det vil være maks 1 telefonnummer"
+        }
+      },
+      "required": ["navn"],
+      "additionalProperties": false
+    },
+    "personnavn": {
+      "type": "object",
+      "properties": {
+        "fornavn": {
+          "type": "string"
+        },
+        "mellomnavn": {
+          "type": "string"
+        },
+        "etternavn": {
+          "type": "string"
+        }
+      },
+      "required": ["fornavn", "etternavn"],
+      "additionalProperties": false
+    },
+    "siktetPerson": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "person": {
+          "$ref": "#/definitions/siktetPersonEnkel",
+          "description": "Siktede har alltid identitetsnummer (fødselsnummer, dnummer eller SSP nummer)"
+        },
+        "adresseGradering": {
+          "$ref": "#/definitions/adresseGradering",
+          "description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå"
+        },
+        "personAdresse": {
+          "$ref": "#/definitions/personAdresse"
+        },
+        "kontaktInfo": {
+          "$ref": "#/definitions/kontaktInfo",
+          "description": "Hvis det finnes registrert på personen i BL."
+        },
+        "verger": {
+          "type": "array",
+          "description": "Verger trenger ikke å ha fødselsnummer og vil aldri ha SSP nummer",
+          "items": {
+            "$ref": "#/definitions/relatertPersonEnkel"
+          }
+        }
+      },
+      "required": ["person", "verger"],
+      "additionalProperties": false
+    },
+    "siktetPersonEnkel": {
+      "type": "object",
+      "description": "Siktede, dømte, tiltalte... personer bruker denne typen for identifiserende data.",
+      "properties": {
+        "personForetakRef": {
+          "$ref": "#/definitions/GUID",
+          "description": "Unik id kun lokalt i en melding, samme person kun i denne meldingen vil ha samme personForetakRef."
+        },
+        "personStraffesakId": { "$ref": "#/definitions/personStraffesakId" },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": { "$ref": "#/definitions/dato" },
+        "kjoenn": {
+          "$ref": "#/definitions/kjoenn",
+          "description": "Ukjent kjønn hvis denne ikke er med"
+        },
+        "statsborgerskap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/land"
+          }
+        },
+        "identitetsnummer": {
+          "$ref": "#/definitions/personIdentifikator",
+          "description": "Fødselsnummer, D-nummer eller SSP nummer som er i bruk. Siktede vil alltid ha med denne."
+        },
+        "tilleggsId": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/personIdentifikator"
+          },
+          "description": "Kan være SSP nummer hvis person har D-nummer, fremtidig historiske nummer?"
+        }
+      },
+      "required": [
+        "personForetakRef",
+        "navn",
+        "foedselsdato",
+        "statsborgerskap",
+        "tilleggsId",
+        "identitetsnummer"
+      ],
+      "additionalProperties": false
+    },
+    "relatertPerson": {
+      "type": "object",
+      "description": "Person med adresser og mulige verger",
+      "properties": {
+        "person": { "$ref": "#/definitions/relatertPersonEnkel" },
+        "adresseGradering": {
+          "$ref": "#/definitions/adresseGradering",
+          "description": "Settes hvis en person har en beskyttet adresse. Fortrolig så sendes ikke adresse, strengt fortrolig så sendes pboks. adresse f.eks. SOT6, klient adresse vet ikke ennå"
+        },
+        "personAdresse": {
+          "$ref": "#/definitions/personAdresse"
+        },
+        "verger": {
+          "type": "array",
+          "description": "Verger trenger ikke å ha fødselsnummer og vil aldri ha SSP nummer",
+          "items": {
+            "$ref": "#/definitions/relatertPersonEnkel"
+          }
+        }
+      },
+      "required": ["person", "verger"],
+      "additionalProperties": false
+    },
+    "relatertPersonEnkel": {
+      "type": "object",
+      "description": "Personer som er fornærmed, vitner, verger der det ikke er krav om fødselsnummer, adresse",
+      "properties": {
+        "personForetakRef": {
+          "$ref": "#/definitions/GUID",
+          "description": "unik id kun lokalt i en melding, samme personForetakRef er samme person."
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": { "$ref": "#/definitions/dato" },
+        "kjoenn": {
+          "$ref": "#/definitions/kjoenn",
+          "description": "Ukjent kjønn hvis denne ikke er med"
+        },
+        "statsborgerskap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/land"
+          }
+        },
+        "identitetsnummer": {
+          "$ref": "#/definitions/personIdentifikator",
+          "description": "Fødselsnummer eller D-nummer. Vitner og verger skal aldri ha SSP nummer"
+        }
+      },
+      "required": ["personForetakRef", "navn", "statsborgerskap"],
+      "additionalProperties": false
+    },
+    "kjoenn": {
+      "type": "string",
+      "description": "Samme enum som folkeregisteret",
+      "enum": ["KVINNE", "MANN"]
+    },
+    "personStraffesakId": {
+      "$ref": "#/definitions/unikId",
+      "description": "Referanse til person i straffesak, se readme"
+    },
+    "personIdentifikator": {
+      "type": "object",
+      "description": "Fødselsnummer (inkl. Tenor), DNummer (inkl Tenor) eller SSP nummer som alle validerer til Modulus 11",
+      "properties": {
+        "idType": { "$ref": "#/definitions/personIdType" },
+        "verdi": {
+          "type": "string",
+          "description": "Se skatteetaten. Kan være vanlig med 6 sifret fødselsdato og fiktivt (Tenor) fødselsnummer med +80 på måned slik at noen født 10.01.1990 begynner fiktivt nummer med 108190",
+          "pattern": "^[0-7][0-9][012389][0-9]+$",
+          "minLength": 11,
+          "maxLength": 11
+        }
+      },
+      "required": ["idType", "verdi"],
+      "additionalProperties": false
+    },
+    "personIdType": {
+      "type": "string",
+      "description": "Person ID typer, alle valideres med Modulus 11",
+      "enum": ["FOEDSELSNUMMER", "DNUMMER", "SSPNUMMER"]
+    },
+    "adresse": {
+      "type": "object",
+      "properties": {
+        "adresselinjer": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "maxItems": 4
+        },
+        "postnummer": {
+          "type": "string"
+        },
+        "poststed": {
+          "type": "string"
+        },
+        "land": {
+          "$ref": "#/definitions/land"
+        }
+      },
+      "required": ["adresselinjer", "land"],
+      "additionalProperties": false
+    },
+    "adresseGradering": {
+      "type": "string",
+      "description": "Samme enum som folkeregisteret, ugradert hvis den ikke er gradert",
+      "enum": ["KLIENT_ADRESSE", "FORTROLIG", "STRENGT_FORTROLIG"]
+    },
+    "personAdresse": {
+      "type": "object",
+      "description": "Kan være graderte adresser",
+      "properties": {
+        "gradering": {
+          "$ref": "#/definitions/adresseGradering",
+          "description": "Vi sender ikke med graderte adresser bortsett fra kanskje KLIENT_ADRESSE (sjekker)"
+        },
+        "adresse": {
+          "$ref": "#/definitions/adresse"
+        }
+      },
+      "required": ["adresse"],
+      "additionalProperties": false
+    },
+    "kontaktInfo": {
+      "type": "object",
+      "description": "Skal aldri forekomme med ingen verdier på epost eller telefonnummer",
+      "properties": {
+        "epost": {
+          "type": "string"
+        },
+        "telefonnummer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/telefonnummer"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "dokument": {
+      "type": "object",
+      "description": "Dokument som oversendes på justishub",
+      "properties": {
+        "dokumentRef": {
+          "$ref": "#/definitions/GUID",
+          "description": "Unik id for dokumentet kun lokalt i en melding. Bruker dokumentRef for å referere"
+        },
+        "kategori": {
+          "$ref": "#/definitions/kodeverk"
+        },
+        "overskrift": {
+          "type": "string",
+          "description": "Overskrift/tittel i straffesaken sin dokumentliste, er ikke det samme som tittel skrevet inn i dokumentet"
+        },
+        "skrevetDato": {
+          "$ref": "#/definitions/dato",
+          "description": "Når dokumentet er skrevet ferdig."
+        },
+        "forsendelse": {
+          "$ref": "#/definitions/dokumentForsendelse"
+        }
+      },
+      "required": ["overskrift", "skrevetDato", "forsendelse"],
+      "additionalProperties": false
+    },
+    "dokumentForsendelse": {
+      "type": "object",
+      "description": "Detaljer om lokasjon og type",
+      "properties": {
+        "mimeType": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "sjekksum": {
+          "type": "string"
+        }
+      },
+      "required": ["mimeType", "uri", "sjekksum"],
+      "additionalProperties": false
+    },
+    "kodeverk": {
+      "type": "object",
+      "properties": {
+        "kode": {
+          "type": "string"
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["kode"],
+      "additionalProperties": false
+    },
+    "land": {
+      "type": "object",
+      "description": "ISO-3166, Kosovo kommer",
+      "properties": {
+        "kode": {
+          "type": "string",
+          "pattern": "^[A-Z]+$",
+          "minLength": 3,
+          "maxLength": 3
+        },
+        "navn": {
+          "type": "string"
+        }
+      },
+      "required": ["kode", "navn"],
+      "additionalProperties": false
+    },
+    "organisasjonsnummer": {
+      "type": "string",
+      "description": "Norsk organisasjonsnummer fra BRREG. Referanse til politistrikt, domstol, fengsel. https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/organisasjonsnummeret/",
+      "pattern": "^[0-9]+$",
+      "minLength": 9,
+      "maxLength": 9
+    },
+    "epost": {
+      "type": "string",
+      "format": "email"
+    },
+    "norskPostnummer": {
+      "type": "string",
+      "description": "Norsk postnummer er i dag 4 siffer",
+      "pattern": "^[0-9]+$",
+      "minLength": 4,
+      "maxLength": 4
+    },
+    "straffesaksnummer": {
+      "type": "string",
+      "description": "Som regel et løpenummer, men kan i fremtiden også inneholde bokstaver",
+      "minLength": 3,
+      "maxLength": 30
+    },
+    "aar": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 21
+    },
+    "maaneder": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 99
+    },
+    "dager": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 999
+    },
+    "timer": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 999
+    },
+    "datoTid": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "dato": {
+      "type": "string",
+      "format": "date"
+    },
+    "telefonnummer": {
+      "type": "string",
+      "description": "Ett telefonnummer, norsk eller utenlands, med eller uten land prefix. Tillater +før landkode, - tegn, space og paranteser.",
+      "pattern": "^\\+?[0-9 ()-]*$",
+      "maxLength": 30,
+      "minLength": 3
+    },
+    "unikId": {
+      "type": "string",
+      "description": "GUID eller andre unike id'er. Trenger ikke være global unik.",
+      "maxLength": 40,
+      "minLength": 5
+    },
+    "GUID": {
+      "type": "string",
+      "format": "uuid"
+    }
+  }
+}

--- a/kontrakter/dom/fullbyrdelsesordre/changelog.md
+++ b/kontrakter/dom/fullbyrdelsesordre/changelog.md
@@ -1,9 +1,16 @@
 # Endringslogg fullbyrdelsesordre
 
 | Versjon | Beskrivelse   | Aktiv fra | Aktiv til |
-| ------- | ------------- | --------- | --------- |
-| 0.0     | Arbeidsverson |           |           |
+|---------| ------------- | --------- | --------- |
+| 1.1    |besluttetAv... |      |   |
+| 1.0     | Arbeidsverson |           |           |
 
+## Besluttet av til versjon 1.1 (ESAS-1798)
+Kjører versjonering selv om vi ikke er i produksjon for å kunne følge med en del endringer.
+* Fullbyrdelse besluttet av lagt til.
+* Domstolen som har avsagt dommen lagt til.
+* Grunnlagsteksten lagt til.
+* Skrivefeil hjemmler -> hjemler.
 ## Versjon 1.0 med detaljer på hjemler
 KDI ønsker detaljerte hjemler definisjon for å forberede mottak av de i Koda.
 ## Versjon 1.0

--- a/kontrakter/dom/fullbyrdelsesordre/readme.md
+++ b/kontrakter/dom/fullbyrdelsesordre/readme.md
@@ -1,9 +1,5 @@
 # Fullbyrdelsesordre - ikke i produksjon
-
-Versjon 1.0 er første versjon som vi skal i produksjon med sammen med tilståelsessaker.
-
 ## Headere forsendelse justisHub
-
 SchemaName=FULLBYRDELSESORDRE  
 SchemaVersion=1.0  
 senderOrganization=POLITIET  


### PR DESCRIPTION
Delt 302 i to, denne inneholder ekstra informasjon som beskrevet i changelog.md:
## Besluttet av til versjon 1.1 (ESAS-1798)
Kjører versjonering selv om vi ikke er i produksjon for å kunne følge med en del endringer.
* Fullbyrdelse besluttet av lagt til.
* Domstolen som har avsagt dommen lagt til.
* Grunnlagsteksten lagt til.
* Skrivefeil hjemmler -> hjemler.
