### PR TITLE
Fullbyrdelsesordre Kontaktinformasjon distrikt

### DIFF
--- a/kontrakter/dom/fullbyrdelsesordre/arbeidsversjon/eksempelfiler/fullbyrdelsesordre-eksempel-1.json
+++ b/kontrakter/dom/fullbyrdelsesordre/arbeidsversjon/eksempelfiler/fullbyrdelsesordre-eksempel-1.json
@@ -12,11 +12,13 @@
           "etternavn": "Gunnarsen",
           "fornavn": "Gunnar"
         },
-        "tittel": "Konsulent",
-        "kontakt": {
-          "epost": "gunnar.gunnarsen@politi.no"
-        }
+        "tittel": "Konsulent"
       }
+    },
+    "kontakt": {
+      "beskrivelse": "Distrikt sentralbord/postmottak",
+      "epost": "distrikt@politiet.no",
+      "telefonnummer": "88888888"
     },
     "mottakerOrganisasjon": {
       "organisasjonsnummer": "983997953",
@@ -31,11 +33,7 @@
         "etternavn": "Klausonius",
         "fornavn": "Lars"
       },
-      "tittel": "Påtaleansvarlig",
-      "kontakt": {
-        "epost": "lars.klausonius@politiet.no",
-        "telefonnummer": ["0047 97 97 97 97"]
-      }
+      "tittel": "Påtaleansvarlig"
     },
     "besluttetAv": {
       "navn": {

--- a/kontrakter/dom/fullbyrdelsesordre/arbeidsversjon/fullbyrdelsesordre.schema.json
+++ b/kontrakter/dom/fullbyrdelsesordre/arbeidsversjon/fullbyrdelsesordre.schema.json
@@ -593,6 +593,10 @@
         },
         "sendtTid": { "$ref": "#/definitions/datoTid" },
         "avsender": { "$ref": "#/definitions/avsender" },
+        "kontakt": {
+          "$ref": "#/definitions/kontaktInfo",
+          "description": "Distriktet sin kontaktinformasjon"
+        },
         "mottakerOrganisasjon": {
           "$ref": "#/definitions/organisasjon",
           "description": "Domstol som skal være mottaker"
@@ -644,10 +648,6 @@
         },
         "navn": {
           "$ref": "#/definitions/personnavn"
-        },
-        "kontakt": {
-          "$ref": "#/definitions/kontaktInfo",
-          "description": "Minimum epost adresse til den som sender melding. Det vil være maks 1 telefonnummer"
         }
       },
       "required": ["navn"],
@@ -685,7 +685,7 @@
           "$ref": "#/definitions/personAdresse"
         },
         "kontaktInfo": {
-          "$ref": "#/definitions/kontaktInfo",
+          "$ref": "#/definitions/kontaktInfoPerson",
           "description": "Hvis det finnes registrert på personen i BL."
         },
         "verger": {
@@ -870,6 +870,22 @@
       "additionalProperties": false
     },
     "kontaktInfo": {
+      "type": "object",
+      "description": "Generell kontaktinformasjon til distriktet/embetet",
+      "properties": {
+        "beskrivelse": {
+          "type": "string",
+          "description": "Beskrivelse f.eks. sentralbord"
+        },
+        "epost": {
+          "$ref": "#/definitions/epost"
+        },
+        "telefonnummer": { "$ref": "#/definitions/telefonnummer" }
+      },
+      "required": ["telefonnummer"],
+      "additionalProperties": false
+    },
+    "kontaktInfoPerson": {
       "type": "object",
       "description": "Skal aldri forekomme med ingen verdier på epost eller telefonnummer",
       "properties": {

--- a/kontrakter/dom/fullbyrdelsesordre/changelog.md
+++ b/kontrakter/dom/fullbyrdelsesordre/changelog.md
@@ -1,9 +1,9 @@
 # Endringslogg fullbyrdelsesordre
 
-| Versjon | Beskrivelse   | Aktiv fra | Aktiv til |
-|---------| ------------- | --------- | --------- |
-| 1.1    |besluttetAv... |      |   |
-| 1.0     | Arbeidsverson |           |           |
+| Versjon | Beskrivelse         | Aktiv fra | Aktiv til |
+|---------|---------------------| --------- | --------- |
+| 1.1    | besluttetAv/kontakt |      |   |
+| 1.0     | Arbeidsverson       |           |           |
 
 ## Besluttet av til versjon 1.1 (ESAS-1798)
 Kjører versjonering selv om vi ikke er i produksjon for å kunne følge med en del endringer.
@@ -11,6 +11,11 @@ Kjører versjonering selv om vi ikke er i produksjon for å kunne følge med en 
 * Domstolen som har avsagt dommen lagt til.
 * Grunnlagsteksten lagt til.
 * Skrivefeil hjemmler -> hjemler.
+### Kontaktinformassjon
+Tilbakemeldinger så langt sier at det er feil å oppgi avsender og påtaleansvarlig sitt telefonnummer.
+* Vi har ikke gode nok data på personer sin telefonnummer.
+* Det er ofte andre personer som skal kontaktes (avdeling)
+* Vi velger derfor å oppgi distriktet sitt sentralbord som standard på alle meldinger som trenger kontaktdetaljer.
 ## Versjon 1.0 med detaljer på hjemler
 KDI ønsker detaljerte hjemler definisjon for å forberede mottak av de i Koda.
 ## Versjon 1.0


### PR DESCRIPTION
Tilbakemeldinger så langt sier at det er feil å oppgi avsender og påtaleansvarlig sitt telefonnummer.
* Vi har ikke gode nok data på personer sin telefonnummer.
* Det er ofte andre personer som skal kontaktes (avdeling)
* Vi velger derfor å oppgi distriktet sitt sentralbord som standard på alle meldinger som trenger kontaktdetaljer.