### PR TITLE
Forslag: Oppnevnt forsvarer i varetektskjennelsepoliti

### DIFF
--- a/kontrakter/varetekt/kjennelsevaretektpoliti/arbeidsversjon/kjennelseVaretektPoliti.schema.json
+++ b/kontrakter/varetekt/kjennelsevaretektpoliti/arbeidsversjon/kjennelseVaretektPoliti.schema.json
@@ -525,6 +525,10 @@
           "type": "array",
           "description": "Verge skal være med på siktet, fornærmet, vitne.",
           "items": { "$ref": "#/definitions/personRelatert" }
+        },
+        "oppnevntForsvarer": {
+          "$ref": "#/definitions/personForsvarer",
+          "description": "Informasjon om oppnevnt forsvarer. Personen som står som oppnevnt forsvarer når avgjørselsen blir sendt."
         }
       },
       "required": [
@@ -534,6 +538,33 @@
         "tilleggsId",
         "verger"
       ],
+      "additionalProperties": false
+    },
+    "personForsvarer": {
+      "type": "object",
+      "description": "Forsvareren som bistår siktede eller tiltalte i straffesaken (advokat, advokatfullmektig eller annen egnet person.)",
+      "properties": {
+        "tittel": { 
+          "type": "string",
+          "description": "F.eks 'Advokatfullmektig'." 
+        },
+        "navn": { 
+          "$ref": "#/definitions/personnavn" 
+        },
+        "foedselsnummer": {
+          "$ref": "#/definitions/foedselsnummer",
+          "description": "Fødsels- og personnummer."
+        },
+        "kontaktInfo": {
+          "$ref": "#/definitions/kontaktInfo",
+          "description": "Kontaktinfo til forsvarer."
+        },
+        "virksomhet": {
+          "$ref": "#/definitions/foretak",
+          "description": "Engasjert advokatforetak, enkeltpersonforetak eller annen organisasjon som forsvarer praktiserer ut i fra i den aktuelle saken."
+        }
+      },
+      "required": ["navn", "foedselsnummer", "virksomhet"],
       "additionalProperties": false
     },
     "personEnkel": {

--- a/kontrakter/varetekt/kjennelsevaretektpoliti/arbeidsversjon/kjennelseVaretektPoliti.schema.json
+++ b/kontrakter/varetekt/kjennelsevaretektpoliti/arbeidsversjon/kjennelseVaretektPoliti.schema.json
@@ -560,11 +560,23 @@
           "description": "Kontaktinfo til forsvarer."
         },
         "virksomhet": {
-          "$ref": "#/definitions/foretak",
+          "$ref": "#/definitions/advokatvirksomhet",
           "description": "Engasjert advokatforetak, enkeltpersonforetak eller annen organisasjon som forsvarer praktiserer ut i fra i den aktuelle saken."
         }
       },
       "required": ["navn", "foedselsnummer", "virksomhet"],
+      "additionalProperties": false
+    },
+    "advokatvirksomhet": {
+      "description": "Registrert advokatforetak, enkeltpersonforetak eller annen organisasjon som person med advokatbevilling praktiserer ut i fra.",
+      "type": "object",
+      "properties": {
+        "organisasjonsnummer": { "$ref": "#/definitions/organisasjonsnummer" },
+        "navn": { "type": "string" },
+        "adresse": { "$ref": "#/definitions/adresse" },
+        "postadresse": { "$ref": "#/definitions/adresse" }
+      },
+      "required": ["organisasjonsnummer"],
       "additionalProperties": false
     },
     "personEnkel": {


### PR DESCRIPTION
Lagt til initiellt forslag til struktur for oppnevnt forsvarer i varetektskjennelse (politi-versjonen som sendes til kriminalomsorgen) til diskusjon. 

Informasjonselementer: 

- Tittel (Eg. "Advokatfullmektig")
- Navn  (Eg. "Per Gunnar Hansen Nilsson")
- Fødsels- og personnummer
- Kontaktinfo (Telefon, epost)
- Virksomhet (Orgnr, navn, adresse)

Til avklaring: 

- Vil en oppnevnt forsvarer alltid være tilknyttet en virksomhet?
- Bør vi ha med "dato oppnevnt forsvarer for siktet/tiltalt" i og med at denne personen kan endre seg mellom førstegangsfengsling og forlengelser?

Inspirasjon: 
https://www.domstol.no/contentassets/311259056aa24c01ac3051bce39e5023/oversikt-over-faste-forsvarere.pdf
https://tilsynet.no/register/advokatregister?company=true&companyNr=001P6000005BiB6IAK

Bakgrunn: 
Oppnevnt forsvarer følger gjerne med ustrukturert i "papirene" til en fengslings-kjennelse i dag slik at anstalt har denne informasjonen. Denne endringen sikrer at oppnevnt forsvarer ved avgjørelse-tidspunktet blir kommunisert strukturert til kriminalomsorgen. 
Det er dog vanlig med forsvarerbytte og denne endringen sikrer ikke at anstalt er holdt oppdatert om hvem som er oppnevnt forsvarer. Det er en utfordring ved f.eks besøk i fengsel. 
