### PR TITLE
Lagt til pakkeId på bestilling av varetektsplass

### DIFF
--- a/kontrakter/varetekt/bestillingVaretektsplass/arbeidsversjon/bestillingVaretektsplass.schema.json
+++ b/kontrakter/varetekt/bestillingVaretektsplass/arbeidsversjon/bestillingVaretektsplass.schema.json
@@ -7,6 +7,10 @@
     "forsendelse": {
       "$ref": "#/definitions/forsendelse"
     },
+    "pakkeId": {
+      "$ref": "#/definitions/GUID",
+      "description": "Hvis meldingen sendes sammen med flere f.eks. siktelse, så vil alle meldingene ha samme pakkeId."
+    },
     "anmodningsId": {
       "$ref": "#/definitions/GUID",
       "description": "Unik nøkkel på bestillingen, brukes til å koble svar fra KO, siktelse og helse og risiko."

--- a/kontrakter/varetekt/bestillingVaretektsplass/arbeidsversjon/eksempelfiler/bestillingVaretektsplass-eksempel-1.json
+++ b/kontrakter/varetekt/bestillingVaretektsplass/arbeidsversjon/eksempelfiler/bestillingVaretektsplass-eksempel-1.json
@@ -20,6 +20,7 @@
       "navn": "Kriminalomsorgsdirektoratet"
     }
   },
+  "pakkeId": "CADC75FC-22EF-478E-B4EC-27C49F85FD70",
   "hovedStraffesaksnummer": "15434811",
   "paataleansvarlig": {
     "navn": {


### PR DESCRIPTION
Lagt til pakkeId for å kunne identifisere meldinger som hører sammen.

Ikke required da man ikke altid har siktelse når man sender bestillingen.