### PR TITLE
Kodeverk format

### DIFF
--- a/kontrakter/felles/kodeverk/arbeidsversjon/eksempelfiler/kodeverk-eksempel-1.json
+++ b/kontrakter/felles/kodeverk/arbeidsversjon/eksempelfiler/kodeverk-eksempel-1.json
@@ -1,0 +1,29 @@
+{
+  "kodeType": "POLITI_DOK",
+  "beskrivelse": "Testliste med rare ting",
+  "koder": [
+    {
+      "kode": "SIKTELSE",
+      "beskrivelse": "Siktelse følger med tvangsmidler og tilståelsessaker",
+      "navn": "Siktelse"
+    },
+    {
+      "kode": "T1ILTALTE_1",
+      "navn": "Tiltale til hovedforhandlinger"
+    },
+    {
+      "kode": "PÅTEGNING_1",
+      "navn": "Følger med en forsendelse, beskrivelse hva som følger med"
+    },
+    {
+      "kode": "1BEGJ_O",
+      "navn": "Begjæering om varetket dokument (skulle hatt noe mer generelt)"
+    },
+    {
+      "kode": "JALLA",
+      "beskrivelse": "Kode gyldig til og med 2023-03-31",
+      "navn": "Bare tull",
+      "gyldigTil": "2023-04-01"
+    }
+  ]
+}

--- a/kontrakter/felles/kodeverk/arbeidsversjon/kodeverk.schema.json
+++ b/kontrakter/felles/kodeverk/arbeidsversjon/kodeverk.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://domstol.no/felles/arbeidsversjon/kodeverk.schema.json",
+  "description": "Kodeverk liste som er definert i json filer i felles repo",
+
+  "type": "object",
+  "properties": {
+    "kodeType": {
+      "$ref": "#/definitions/kodeType",
+      "description": "unik id som anngir denne kodeverkslisten"
+    },
+    "beskrivelse": { "type": "string" },
+    "koder": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/kodeverkDefinisjon"
+      }
+    }
+  },
+  "required": ["kodeType", "koder"],
+  "additionalProperties": false,
+
+  "definitions": {
+    "kodeverkDefinisjon": {
+      "type": "object",
+      "description": "En kodeverk definisjon som brukes i definisjonen av kodeverk objekt",
+      "properties": {
+        "kode": {
+          "$ref": "#/definitions/kode"
+        },
+        "beskrivelse": {
+          "type": "string",
+          "maxLength": 250,
+          "minLength": 2
+        },
+        "navn": {
+          "type": "string",
+          "description": "Navn for visning til bruker",
+          "maxLength": 250,
+          "minLength": 2
+        },
+        "kortNavn": {
+          "type": "string",
+          "maxLength": 50,
+          "minLength": 1
+        },
+        "gyldigTil": {
+          "type": "string",
+          "description": "Gyldig til dato, dvs. 2023-04-01 betyr gyldig til og med 2023-03-31",
+          "format": "date"
+        }
+      },
+      "required": ["kode", "navn"],
+      "additionalProperties": false
+    },
+    "kode": {
+      "type": "string",
+      "pattern": "^[A-Z,Æ,Ø,Å,0-9][A-Z,Æ,Ø,Å,0-9,_]*$",
+      "maxLength": 50,
+      "minLength": 1
+    },
+    "kodeType": {
+      "type": "string",
+      "description": "unik id for denne typen koder.",
+      "pattern": "^[A-Z,Æ,Ø,Å,0-9][A-Z,Æ,Ø,Å,0-9,_]*$",
+      "maxLength": 50,
+      "minLength": 1
+    }
+  }
+}

--- a/kontrakter/felles/kodeverk/changelog.md
+++ b/kontrakter/felles/kodeverk/changelog.md
@@ -1,0 +1,6 @@
+# Endringslogg felles kodeverk schema
+
+## 23.04.2025
+Endringer med navn istedet for beskrivelse.
+Beskrivelse er nå frivillig felt som kan beskrive koden ved behov.
+kortNavn som frivillig felt.


### PR DESCRIPTION
Forslag til endringer på felles kodeverk:
navn istedet for beskrivelse.
Beskrivelse er nå frivillig felt som kan beskrive koden ved behov.
kortNavn som frivillig felt.