### PR TITLE
Straffesak informasjon kobling på personer

### DIFF
--- a/kontrakter/kjennelseBeslutning/begjaeringKjennelseBeslutning/arbeidsversjon/begjaeringKjennelseBeslutning.schema.json
+++ b/kontrakter/kjennelseBeslutning/begjaeringKjennelseBeslutning/arbeidsversjon/begjaeringKjennelseBeslutning.schema.json
@@ -120,7 +120,7 @@
       "properties": {
         "siktedePersoner": {
           "type": "array",
-          "description": "Alle siktede personer",
+          "description": "Alle siktede personer, kobling til straffesakene finnes i siktelsen.",
           "items": { "$ref": "#/definitions/siktetPersonInfo" }
         },
         "siktedeForetak": {
@@ -130,23 +130,25 @@
         },
         "fornaermedePersoner": {
           "type": "array",
-          "description": "Alle fornærmede personer",
-          "items": { "$ref": "#/definitions/relatertPerson" }
+          "description": "Alle fornærmede personer, med kobling til straffesaken",
+          "items": { "$ref": "#/definitions/relatertPersonStraffesak" }
         },
         "fornaermedeForetak": {
           "type": "array",
-          "description": "Alle fornærmede foretak",
-          "items": { "$ref": "#/definitions/foretak" }
+          "description": "Alle fornærmede foretak, med kobling til straffesaken",
+          "items": { "$ref": "#/definitions/foretakStraffesak" }
         },
         "vitner": {
           "type": "array",
           "description": "Alle vitner med informasjon om hvilke straffesaker de er vitne i",
-          "items": { "$ref": "#/definitions/relatertPerson" }
+          "items": { "$ref": "#/definitions/relatertPersonStraffesak" }
         },
         "andrePersoner": {
           "type": "array",
           "description": "Profesjonelle vitner (politi), sakkyndige o.l.",
-          "items": { "$ref": "#/definitions/profesjonellPersonMedRolle" }
+          "items": {
+            "$ref": "#/definitions/profesjonellPersonMedRolleStraffesak"
+          }
         }
       },
       "required": [
@@ -623,21 +625,37 @@
       "required": ["person"],
       "additionalProperties": false
     },
-    "fornaermedePersoner": {
-      "type": "array",
-      "description": "Alle fornærmede personer, kobling til straffesaken i siktelseTiltale",
-      "items": { "$ref": "#/definitions/relatertPerson" }
-    },
-    "fornaermedeForetak": {
-      "type": "array",
-      "description": "Alle fornærmede foretak, kobling til straffesaken i siktelseTiltale",
-      "items": { "$ref": "#/definitions/foretakStraffesak" }
-    },
     "foretakStraffesak": {
       "type": "object",
       "description": "Foretak med kobling til straffesakene de er med i",
       "properties": {
         "person": { "$ref": "#/definitions/foretak" },
+        "straffesaker": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/straffesaksnummer" }
+        }
+      },
+      "required": ["person", "straffesaker"],
+      "additionalProperties": false
+    },
+    "relatertPersonStraffesak": {
+      "type": "object",
+      "description": "Fornærmede, vitne informasjon med kobling til straffesakene de er med i",
+      "properties": {
+        "person": { "$ref": "#/definitions/relatertPerson" },
+        "straffesaker": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/straffesaksnummer" }
+        }
+      },
+      "required": ["person", "straffesaker"],
+      "additionalProperties": false
+    },
+    "profesjonellPersonMedRolleStraffesak": {
+      "type": "object",
+      "description": "Andre personer med kobling til Straffesak",
+      "properties": {
+        "person": { "$ref": "#/definitions/profesjonellPersonMedRolle" },
         "straffesaker": {
           "type": "array",
           "items": { "$ref": "#/definitions/straffesaksnummer" }

--- a/kontrakter/kjennelseBeslutning/begjaeringKjennelseBeslutning/arbeidsversjon/eksempelfiler/begjaeringKjennelseBeslutning-eksempel-1.json
+++ b/kontrakter/kjennelseBeslutning/begjaeringKjennelseBeslutning/arbeidsversjon/eksempelfiler/begjaeringKjennelseBeslutning-eksempel-1.json
@@ -93,24 +93,27 @@
     "fornaermedePersoner": [
       {
         "person": {
-          "personForetakRef": "333E0F52-9DDB-40E7-BDF3-663B8AC93CE2",
-          "navn": {
-            "fornavn": "Sannferdig",
-            "etternavn": "KOS"
-          },
-          "identitetsnummer": {
-            "idType": "FOEDSELSNUMMER",
-            "verdi": "31907499858"
-          },
-          "kjoenn": "KVINNE",
-          "foedselsdato": "1974-10-31",
-          "statsborgerskap": [
-            {
-              "kode": "NOR",
-              "navn": "Norge"
-            }
-          ]
-        }
+          "person": {
+            "personForetakRef": "333E0F52-9DDB-40E7-BDF3-663B8AC93CE2",
+            "navn": {
+              "fornavn": "Sannferdig",
+              "etternavn": "KOS"
+            },
+            "identitetsnummer": {
+              "idType": "FOEDSELSNUMMER",
+              "verdi": "31907499858"
+            },
+            "kjoenn": "KVINNE",
+            "foedselsdato": "1974-10-31",
+            "statsborgerskap": [
+              {
+                "kode": "NOR",
+                "navn": "Norge"
+              }
+            ]
+          }
+        },
+        "straffesaker": ["15439560"]
       }
     ],
     "fornaermedeForetak": [],

--- a/kontrakter/kjennelseBeslutning/begjaeringKjennelseBeslutning/changelog.md
+++ b/kontrakter/kjennelseBeslutning/begjaeringKjennelseBeslutning/changelog.md
@@ -2,3 +2,8 @@
 | Versjon | Beskrivelse      | Aktiv mottaker | Aktiv sender | 
 |---------|------------------|----------------|--------------|
 | 1.0     | Initiell versjon |                |              |
+ | arbeidsversjon | straffesaker     |  | |
+
+## 1.1 Legger til kobling av straffesak
+Legges på alle roller som ikke er siktede. Siktede har kobling til straffesaken gjennom siktelsen.
+**OBS** Siktelsen inneholder ikke strukturert informasjon om fornærmede.


### PR DESCRIPTION
Detaljer om straffesakene som gjerningssted, tid osv. ligger i siktelsen som følger med.
Det er lagt til kobling fra andre roller som fornærmede til straffesaker da den informasjonen ikke ligger i siktelsen.

Det er slettet noen definisjoner som ikke brukes.