### PR TITLE
Korrigerer def av verge for 1.0 anmodning egnethetsvurdering VTEK

### DIFF
--- a/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/1.0/anmodningOmEgnethetsvurdering.schema.json
+++ b/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/1.0/anmodningOmEgnethetsvurdering.schema.json
@@ -143,7 +143,7 @@
       "type": "object",
       "properties": {
         "person": {
-          "$ref": "#/definitions/person"
+          "$ref": "#/definitions/relatertPersonEnkel"
         },
         "samtykkeInnhentet": {
           "$ref": "#/definitions/samtykkeDetaljer"
@@ -237,6 +237,39 @@
         }
       },
       "required": ["internId", "navn", "foedselsdato", "statsborgerskap"],
+      "additionalProperties": false
+    },
+    "relatertPersonEnkel": {
+      "type": "object",
+      "description": "Personer som er fornærmed, vitner, verger der det ikke er krav om fødselsnummer, osv.",
+      "properties": {
+        "personForetakRef": {
+          "$ref": "#/definitions/unikId",
+          "description": "unik id kun lokalt i en melding, samme personForetakRef er samme person."
+        },
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": {
+          "type": "string",
+          "format": "date"
+        },
+        "kjoenn": {
+          "$ref": "#/definitions/kjoenn",
+          "description": "Ukjent kjønn hvis denne ikke er med"
+        },
+        "statsborgerskap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/land"
+          }
+        },
+        "identitetsnummer": {
+          "$ref": "#/definitions/personIdentifikator",
+          "description": "Fødselsnummer eller D-nummer. Vitner og verger skal aldri ha SSP nummer"
+        }
+      },
+      "required": ["personForetakRef", "navn", "statsborgerskap"],
       "additionalProperties": false
     },
     "forsendelse": {

--- a/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/1.0/anmodningOmEgnethetsvurdering.schema.json
+++ b/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/1.0/anmodningOmEgnethetsvurdering.schema.json
@@ -243,10 +243,6 @@
       "type": "object",
       "description": "Personer som er fornærmed, vitner, verger der det ikke er krav om fødselsnummer, osv.",
       "properties": {
-        "personForetakRef": {
-          "$ref": "#/definitions/unikId",
-          "description": "unik id kun lokalt i en melding, samme personForetakRef er samme person."
-        },
         "navn": {
           "$ref": "#/definitions/personnavn"
         },
@@ -269,7 +265,7 @@
           "description": "Fødselsnummer eller D-nummer. Vitner og verger skal aldri ha SSP nummer"
         }
       },
-      "required": ["personForetakRef", "navn", "statsborgerskap"],
+      "required": ["navn", "statsborgerskap"],
       "additionalProperties": false
     },
     "forsendelse": {

--- a/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/1.0/eksempelfiler/anmodningOmEgnethetsvurdering-eksempel-1.json
+++ b/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/1.0/eksempelfiler/anmodningOmEgnethetsvurdering-eksempel-1.json
@@ -58,7 +58,6 @@
         "verger": [
           {
             "person": {
-              "internId": "700892638",
               "navn": {
                 "fornavn": "Varg",
                 "etternavn": "VERGERNES"

--- a/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/arbeidsversjon/anmodningOmEgnethetsvurdering.schema.json
+++ b/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/arbeidsversjon/anmodningOmEgnethetsvurdering.schema.json
@@ -143,7 +143,7 @@
       "type": "object",
       "properties": {
         "person": {
-          "$ref": "#/definitions/person"
+          "$ref": "#/definitions/relatertPersonEnkel"
         },
         "samtykkeInnhentet": {
           "$ref": "#/definitions/samtykkeDetaljer"
@@ -237,6 +237,35 @@
         }
       },
       "required": ["internId", "navn", "foedselsdato", "statsborgerskap"],
+      "additionalProperties": false
+    },
+    "relatertPersonEnkel": {
+      "type": "object",
+      "description": "Personer som er fornærmed, vitner, verger der det ikke er krav om fødselsnummer, osv.",
+      "properties": {
+        "navn": {
+          "$ref": "#/definitions/personnavn"
+        },
+        "foedselsdato": {
+          "type": "string",
+          "format": "date"
+        },
+        "kjoenn": {
+          "$ref": "#/definitions/kjoenn",
+          "description": "Ukjent kjønn hvis denne ikke er med"
+        },
+        "statsborgerskap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/land"
+          }
+        },
+        "identitetsnummer": {
+          "$ref": "#/definitions/personIdentifikator",
+          "description": "Fødselsnummer eller D-nummer. Vitner og verger skal aldri ha SSP nummer"
+        }
+      },
+      "required": ["navn", "statsborgerskap"],
       "additionalProperties": false
     },
     "forsendelse": {

--- a/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/arbeidsversjon/eksempelfiler/anmodningOmEgnethetsvurdering-eksempel-1.json
+++ b/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/arbeidsversjon/eksempelfiler/anmodningOmEgnethetsvurdering-eksempel-1.json
@@ -58,7 +58,6 @@
         "verger": [
           {
             "person": {
-              "internId": "700892638",
               "navn": {
                 "fornavn": "Varg",
                 "etternavn": "VERGERNES"


### PR DESCRIPTION
Korrgerer definisjonen av verge til å benytte relatertPersonEnkel i stedet for person. Dette er slik det allerede er gjort blant annet i varetektsbestilling.