### PR TITLE
Legger nye felter til anmodning om egnethetsvurdering VTEK

### DIFF
--- a/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/arbeidsversjon/anmodningOmEgnethetsvurdering.schema.json
+++ b/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/arbeidsversjon/anmodningOmEgnethetsvurdering.schema.json
@@ -64,6 +64,10 @@
         "risikoForholdSiktet": {
           "$ref": "#/definitions/valgBeskrivelse"
         },
+        "infoFraForsvarer": {
+          "description": "Informasjon fra forsvarer som kan ha betydning for vurderingen",
+          "$ref": "#/definitions/valgBeskrivelse"
+        },
         "tidligerePersonundersoekelser": {
           "type": "array",
           "items": {
@@ -76,6 +80,15 @@
             "required": ["dokumentId"],
             "additionalProperties": false
           }
+        },
+        "politiadvokat": {
+          "$ref": "#/definitions/ansattPerson"
+        },
+        "etterforsker": {
+          "$ref": "#/definitions/ansattPerson"
+        },
+        "forsvarer": {
+          "$ref": "#/definitions/ansattPerson"
         }
       },
       "required": ["personForEgnethetsvurdering", "adresseForGjennomfoering"],
@@ -134,6 +147,10 @@
           "items": {
             "$ref": "#/definitions/verge"
           }
+        },
+        "erBarn": {
+          "description": "Hvorvidt beboer er barn av, og beskrivelse av forhold som delt omsorg, samvær, mv.",
+          "$ref": "#/definitions/valgBeskrivelse"
         }
       },
       "required": ["navn"],
@@ -147,6 +164,9 @@
         },
         "samtykkeInnhentet": {
           "$ref": "#/definitions/samtykkeDetaljer"
+        },
+        "tolk": {
+          "$ref": "#/definitions/behovForTolk"
         }
       }
     },
@@ -220,17 +240,7 @@
           }
         },
         "tolk": {
-          "type": "object",
-          "properties": {
-            "behov": {
-              "type": "boolean"
-            },
-            "spraak": {
-              "$ref": "#/definitions/spraakkodeType"
-            }
-          },
-          "required": ["behov"],
-          "additionalProperties": false
+          "$ref": "#/definitions/behovForTolk"
         },
         "behandlingsbehov": {
           "$ref": "#/definitions/valgBeskrivelse"
@@ -570,6 +580,19 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 40
+    },
+    "behovForTolk": {
+      "type": "object",
+      "properties": {
+        "behov": {
+          "type": "boolean"
+        },
+        "spraak": {
+          "$ref": "#/definitions/spraakkodeType"
+        }
+      },
+      "required": ["behov"],
+      "additionalProperties": false
     }
   }
 }

--- a/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/arbeidsversjon/eksempelfiler/anmodningOmEgnethetsvurdering-eksempel-1.json
+++ b/kontrakter/varetektEK/anmodningOmEgnethetsvurdering/arbeidsversjon/eksempelfiler/anmodningOmEgnethetsvurdering-eksempel-1.json
@@ -103,6 +103,25 @@
       "postnummer": "0177",
       "poststed": "OSLO"
     },
+    "beboere": [
+      {
+        "navn": {
+          "fornavn": "Bob",
+          "etternavn": "BEBOERSEN"
+        },
+        "relasjon": "Stesønn",
+        "erBarn": {
+          "valg": true,
+          "beskrivelse": "Siktet kan blir utsatt for vold"
+        },
+        "identitetsnummer": {
+          "foedselsnummer": "15298533119"
+        },
+        "samtykkeInnhentet": {
+          "valg": false
+        }
+      }
+    ],
     "annenSysselsetting": {
       "valg": true,
       "beskrivelse": "Kan gå på jobb"
@@ -123,11 +142,27 @@
       "valg": true,
       "beskrivelse": "Siktet er ofte ruset med risiko for utagering"
     },
+    "infoFraForsvarer": {
+      "valg": true,
+      "beskrivelse": "Forsvarer har gitt informasjon om siktet"
+    },
     "tidligerePersonundersoekelser": [
       {
         "dokumentId": "123234567871"
       }
-    ]
+    ],
+    "forsvarer": {
+      "etternavn": "Eriksen",
+      "kontakt": {
+        "telefonnummer": ["11 99 55 44"]
+      }
+    },
+    "politiadvokat": {
+      "etternavn": "Toresen",
+      "kontakt": {
+        "telefonnummer": ["55 99 88 44"]
+      }
+    }
   },
   "dokumenter": [
     {


### PR DESCRIPTION
Det er tatt en sammenligning av kontrakten i forhold til skjemaet som påtale sender til KO i dagens løsning. Følgende felter foreslås innført, da de er tilstede i nevnte skjema:

- Nytt felt for om beboer er barn av, og hvis ja så kan forhold som delt omsorg, samvær m.v beskrives
- Nytt felt for om forsvarer har bidratt med informasjon som kan da betydning for vurderingen
- Nytt felt for om verge har behov for tolk

- Nytt felt for epost og tlf til politiadvokat
- Nytt felt for epost og tlf til etterforsker
- Nytt felt for epost og tlf til forsvarer