### PR TITLE
Legger til dependabot-gruppe for npm-pakker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      non-major:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Slår sammen PRer for patches og minors. Majors får fortsatt egen PR.