### PR TITLE
Oppdaterer `node` og legger til verifiseringssteg for `mvn`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,12 +21,24 @@ jobs:
       - run: npm run prettier:check
       - run: npm run json:validate
 
+      - name: Set up Java
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+          cache: maven
+
+      - name: Validate Maven build
+        if: ${{ github.event_name == 'pull_request' }}
+        run: mvn verify
+
       - name: Set up Github Packages
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/setup-java@v5
         with: # running setup-java again overwrites the settings.xml
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
           cache: maven
           server-id: github # matches distributionManagement in pom.xml
           server-username: GITHUB_ACTOR

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
 
       - run: npm ci
       - run: npm run prettier:check
@@ -28,7 +28,7 @@ jobs:
           distribution: "temurin"
           java-version: "17"
           cache: maven
-          server-id: github  # matches distributionManagement in pom.xml
+          server-id: github # matches distributionManagement in pom.xml
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.20.0",
-        "ajv-formats": "^3.0.1",
-        "node": "^22.14.0"
+        "ajv-formats": "^3.0.1"
       },
       "devDependencies": {
         "prettier": "3.8.3"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/ajv": {
@@ -72,28 +74,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/node": {
-      "version": "22.14.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-22.14.0.tgz",
-      "integrity": "sha512-7RySsZymL7RSt3EKuKK29JhHh9BQV2xajqTP760PNTdZRtmRHZq1Jogw65qKkjEQKVsns5b5jJpucQyKLk+U8w==",
-      "hasInstallScript": true,
-      "license": "ISC",
-      "dependencies": {
-        "node-bin-setup": "^1.0.0"
-      },
-      "bin": {
-        "node": "bin/node"
-      },
-      "engines": {
-        "npm": ">=5.0.0"
-      }
-    },
-    "node_modules/node-bin-setup": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
-      "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg==",
-      "license": "ISC"
     },
     "node_modules/prettier": {
       "version": "3.8.3",
@@ -153,19 +133,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node": {
-      "version": "22.14.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-22.14.0.tgz",
-      "integrity": "sha512-7RySsZymL7RSt3EKuKK29JhHh9BQV2xajqTP760PNTdZRtmRHZq1Jogw65qKkjEQKVsns5b5jJpucQyKLk+U8w==",
-      "requires": {
-        "node-bin-setup": "^1.0.0"
-      }
-    },
-    "node-bin-setup": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
-      "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg=="
     },
     "prettier": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "esas",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
-  "devDependencies": {
-    "prettier": "3.8.3"
+  "engines": {
+    "node": ">=24"
+  },
+  "volta": {
+    "node": "24.15.0"
   },
   "scripts": {
     "prettier:check": "prettier --check \"kontrakter/**/*.json\"",
@@ -23,7 +25,9 @@
   "homepage": "https://github.com/domstolene/ESAS#readme",
   "dependencies": {
     "ajv": "^8.20.0",
-    "ajv-formats": "^3.0.1",
-    "node": "^22.14.0"
+    "ajv-formats": "^3.0.1"
+  },
+  "devDependencies": {
+    "prettier": "3.8.3"
   }
 }


### PR DESCRIPTION
**Oppdaterer node**
... til node 24, som er LTS.

Fjerner også node som npm dependency, da det ikke gir så mye mening og
kan skape forvirring på versjonering.
Å ha `node` som dependency gjør at npm installerer en node-runtime,
men den vil ikke blir brukt slik som scriptene er nå.
`npm run json:validate` vil fortsatt bruke node runtime fra PATH.

Setter istedet `engines`-propertien i package.json, og pinner en
versjon for volta for de som bruker det.


**Oppdaterer java-versjon og legger til verifiseringssteg i CI**
Ved å ha verifiseringssteg på PR kan man finne ut om java-oppgraderingen brekker før det er merget inn.